### PR TITLE
Fix typo in contact form text

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -78,9 +78,10 @@ const ContactForm: React.FC<ContactFormProps> = ({ simulationResult }) => {
           
           <div className="text-xs space-y-1">
             <p>
-              Parcela calculada pela tabela {simulationResult.amortizacao.toUpperCase()} com taxa de juros de 1,19% a.m. + PCA. Esta taxa pode 
-              sofre alterações de acordo com a análise de crédito. Já estão inclusos custos com 
-              avaliação do imóvel, cartório e impostos.
+              Parcela calculada pela tabela {simulationResult.amortizacao.toUpperCase()} com
+              taxa de juros de 1,19% a.m. + IPCA. Esta taxa pode sofrer alterações de acordo
+              com a análise de crédito. Já estão inclusos custos com avaliação do imóvel,
+              cartório e impostos.
             </p>
             
             {simulationResult.amortizacao === 'SAC' && simulationResult.primeiraParcela && simulationResult.ultimaParcela && (


### PR DESCRIPTION
## Summary
- correct 'PCA' to 'IPCA' in contact form results message
- clarify text string

## Testing
- `npx tsc --noEmit` *(fails: npm can't find packages)*

------
https://chatgpt.com/codex/tasks/task_e_683fae6ee8688320b80a8daaa7c887eb