### PR TITLE
Add tests for formatter utilities

### DIFF
--- a/src/utils/__tests__/formatters.test.ts
+++ b/src/utils/__tests__/formatters.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { norm, formatBRL } from '../formatters';
+
+describe('norm', () => {
+  it('handles empty string', () => {
+    expect(norm('')).toBe(0);
+  });
+
+  it('parses numbers with thousands and decimal separators', () => {
+    expect(norm('1.234,56')).toBeCloseTo(1234.56);
+    expect(norm('1.234.567,89')).toBeCloseTo(1234567.89);
+  });
+
+  it('ignores non numeric characters', () => {
+    expect(norm('R$ 1.234,56 abc')).toBeCloseTo(1234.56);
+    expect(norm('abc')).toBe(0);
+  });
+
+  it('trims surrounding spaces', () => {
+    expect(norm(' 1.234,56 ')).toBeCloseTo(1234.56);
+  });
+});
+
+describe('formatBRL', () => {
+  it('returns empty string for empty value', () => {
+    expect(formatBRL('')).toBe('');
+  });
+
+  it('formats numbers with separators correctly', () => {
+    expect(formatBRL('1234567')).toBe('R$ 1.234.567');
+    expect(formatBRL('1.234.567')).toBe('R$ 1.234.567');
+  });
+
+  it('strips non numeric characters before formatting', () => {
+    expect(formatBRL('R$ 1.234,56')).toBe('R$ 123.456');
+    expect(formatBRL('abc123456')).toBe('R$ 123.456');
+  });
+
+  it('handles values with surrounding spaces', () => {
+    expect(formatBRL(' 1234567 ')).toBe('R$ 1.234.567');
+  });
+});


### PR DESCRIPTION
## Summary
- add vitest unit tests covering `norm` and `formatBRL`
- expand coverage for values with surrounding spaces

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*
- `npx vitest run` *(fails: 403 Forbidden to fetch vitest)*

------
https://chatgpt.com/codex/tasks/task_e_683fb36a9c14832097fa3d57f7423b8e