### PR TITLE
Add custom thumbnail support for hero video

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -84,11 +84,12 @@ const Hero: React.FC = () => {
           {/* Vídeo */}
           <div className="w-full max-w-2xl mx-auto lg:max-w-none">
             <div className="aspect-video rounded-xl overflow-hidden shadow-2xl">
-              <OptimizedYouTube 
+              <OptimizedYouTube
                 videoId="E9lwL6R2l1s"
                 title="Vídeo institucional Libra Crédito"
                 priority={true}
                 className="w-full h-full"
+                thumbnailSrc="/images/media/video-cgi-libra.png"
               />
             </div>
           </div>

--- a/src/components/OptimizedYouTube.tsx
+++ b/src/components/OptimizedYouTube.tsx
@@ -6,27 +6,40 @@ interface OptimizedYouTubeProps {
   title: string;
   className?: string;
   priority?: boolean;
+  /**
+   * Optional path to a custom thumbnail image. When provided the
+   * component skips fetching the default YouTube thumbnails and
+   * uses this image instead.
+   */
+  thumbnailSrc?: string;
 }
 
 const OptimizedYouTube: React.FC<OptimizedYouTubeProps> = ({
   videoId,
   title,
   className = "",
-  priority = false
+  priority = false,
+  thumbnailSrc
 }) => {
   const [isLoaded, setIsLoaded] = useState(false);
   const [thumbnailError, setThumbnailError] = useState(false);
   const iframeRef = useRef<HTMLIFrameElement>(null);
   
   // Tenta primeiro a thumbnail de alta qualidade, se falhar usa a padrão
-  const highQualityThumbnail = `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
-  const fallbackThumbnail = `https://img.youtube.com/vi/${videoId}/0.jpg`;
-  
-  const [currentThumbnail, setCurrentThumbnail] = useState(highQualityThumbnail);
+  const defaultHighQualityThumbnail = `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
+  const defaultFallbackThumbnail = `https://img.youtube.com/vi/${videoId}/0.jpg`;
+
+  const [currentThumbnail, setCurrentThumbnail] = useState(
+    thumbnailSrc || defaultHighQualityThumbnail
+  );
 
   const handleThumbnailError = () => {
-    if (currentThumbnail !== fallbackThumbnail) {
-      setCurrentThumbnail(fallbackThumbnail);
+    if (thumbnailSrc) {
+      setThumbnailError(true);
+      return;
+    }
+    if (currentThumbnail !== defaultFallbackThumbnail) {
+      setCurrentThumbnail(defaultFallbackThumbnail);
     } else {
       setThumbnailError(true);
     }


### PR DESCRIPTION
## Summary
- add optional `thumbnailSrc` prop to `OptimizedYouTube`
- use a locally hosted preview image for the hero video

## Testing
- `npm run lint` *(fails: Fast refresh warnings and eslint errors unrelated to this change)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683fd190bdd483209241a54c93f8f278