### PR TITLE
Remove invalid nodeVersion from Vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,5 @@
   "installCommand": "npm install --legacy-peer-deps",
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
-  "framework": "vite",
-  "nodeVersion": "18.x"
+  "framework": "vite"
 }


### PR DESCRIPTION
## Summary
- remove `nodeVersion` from `vercel.json`

## Testing
- `npm install --legacy-peer-deps`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684069f787a883208a24ee58687f3c0f