### PR TITLE
Improve LCP by preloading local thumbnail

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     <!-- Preload dos recursos críticos -->
     <link rel="preload" href="/images/logos/libra-logo.png" as="image">
     <!-- Preload do thumbnail do YouTube (LCP) -->
-    <link rel="preload" href="https://i.ytimg.com/vi/E9lwL6R2l1s/hqdefault.jpg" as="image" fetchpriority="high">
+    <link rel="preload" href="/images/media/video-cgi-libra.jpg" as="image" fetchpriority="high">
     <!-- Preload da fonte crítica -->
     <link rel="preload" href="https://fonts.gstatic.com/s/montserrat/v26/JTUSjIg1_i6t8kCHKm459WRhyyTh89ZNpQ.woff2" as="font" type="font/woff2" crossorigin>
 

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -84,10 +84,11 @@ const Hero: React.FC = () => {
           {/* Vídeo - com loading=lazy em mobile */}
           <div className="w-full max-w-2xl mx-auto lg:max-w-none">
             <div className="aspect-video rounded-xl overflow-hidden shadow-2xl">
-              <OptimizedYouTube 
+              <OptimizedYouTube
                 videoId="E9lwL6R2l1s"
                 title="Vídeo institucional Libra Crédito"
                 priority={!isMobile}
+                thumbnailSrc="/images/media/video-cgi-libra.jpg"
                 className="w-full h-full"
               />
             </div>

--- a/src/components/OptimizedYouTube.tsx
+++ b/src/components/OptimizedYouTube.tsx
@@ -6,26 +6,35 @@ interface OptimizedYouTubeProps {
   title: string;
   className?: string;
   priority?: boolean;
+  /**
+   * Optional custom thumbnail to display before the iframe loads.
+   */
+  thumbnailSrc?: string;
 }
 
 const OptimizedYouTube: React.FC<OptimizedYouTubeProps> = ({
   videoId,
   title,
   className = "",
-  priority = false
+  priority = false,
+  thumbnailSrc
 }) => {
   const [isLoaded, setIsLoaded] = useState(false);
   const [thumbnailError, setThumbnailError] = useState(false);
   const iframeRef = useRef<HTMLIFrameElement>(null);
   
-  // Tenta primeiro a thumbnail de alta qualidade, se falhar usa a padrão
-  const highQualityThumbnail = `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
+  // Usa thumbnail customizada se fornecida, senão a do YouTube
+  const remoteThumbnail = `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
   const fallbackThumbnail = `https://img.youtube.com/vi/${videoId}/0.jpg`;
-  
-  const [currentThumbnail, setCurrentThumbnail] = useState(highQualityThumbnail);
+
+  const [currentThumbnail, setCurrentThumbnail] = useState(
+    thumbnailSrc ?? remoteThumbnail
+  );
 
   const handleThumbnailError = () => {
-    if (currentThumbnail !== fallbackThumbnail) {
+    if (currentThumbnail === thumbnailSrc) {
+      setCurrentThumbnail(remoteThumbnail);
+    } else if (currentThumbnail !== fallbackThumbnail) {
       setCurrentThumbnail(fallbackThumbnail);
     } else {
       setThumbnailError(true);


### PR DESCRIPTION
## Summary
- preload local YouTube thumbnail
- allow `OptimizedYouTube` to accept a custom thumbnail and use it in `Hero`

## Testing
- `npm run lint` *(fails: several unrelated eslint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840732dc38483209cb0169e28dac6e8