### PR TITLE
Add hero prerender support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import Hero from './components/Hero';
 import { Skeleton } from "@/components/ui/skeleton";
 import ScrollToTop from '@/components/ScrollToTop';
 
@@ -54,7 +55,7 @@ const App = () => (
         <Suspense fallback={<Loading />}>
           <main id="main-content" tabIndex={-1} className="focus:outline-none">
             <Routes>
-              <Route path="/" element={<Index />} />
+              <Route path="/" element={<><Hero /><Index /></>} />
               <Route path="/vantagens" element={<Vantagens />} />
               <Route path="/quem-somos" element={<QuemSomos />} />
               <Route path="/blog" element={<Blog />} />

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -35,7 +35,7 @@ const Hero: React.FC = () => {
   };
 
   return (
-    <section className="min-h-[100vh] pt-20 md:pt-24 pb-4 bg-gradient-to-br from-[#003399] via-[#0066cc] to-[#00ccff] relative flex flex-col justify-center" aria-labelledby="hero-heading">
+    <section className="hero min-h-[100vh] pt-20 md:pt-24 pb-4 bg-gradient-to-br from-[#003399] via-[#0066cc] to-[#00ccff] relative flex flex-col justify-center" aria-labelledby="hero-heading">
       <div className="container mx-auto px-4 relative z-10 flex-grow flex flex-col justify-center">
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 lg:gap-8 items-center">
           {/* Lado Esquerdo */}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,4 @@
-import { createRoot } from 'react-dom/client'
+import { hydrateRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
 
@@ -21,7 +21,7 @@ const renderApp = () => {
   
   const root = document.getElementById("root");
   if (root) {
-    createRoot(root).render(<App />);
+    hydrateRoot(root, <App />);
   }
 };
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -5,7 +5,6 @@ import Header from '@/components/Header';
 import LoadingSpinner from '@/components/ui/loading-spinner';
 
 // Hero não deve ser lazy loaded pois contém o LCP
-import Hero from '@/components/Hero';
 import TrustBar from '@/components/TrustBar';
 
 // Lazy loading dos componentes pesados
@@ -43,8 +42,6 @@ const Index: React.FC = () => {
     <div className="min-h-screen flex flex-col">
       <Header />
       <main role="main" className="flex-grow">
-        <Hero />
-        
         <TrustBar />
         
         <Suspense fallback={<SectionLoader />}>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,9 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { componentTagger } from "lovable-tagger";
-import prerender from 'vite-plugin-prerender'
+import { createRequire } from 'module'
+const require = createRequire(import.meta.url)
+const prerender = require('vite-plugin-prerender')
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
@@ -14,6 +16,13 @@ export default defineConfig(({ mode }) => ({
     react(),
     mode === 'development' &&
     componentTagger(),
+    prerender({
+      staticDir: path.join(__dirname, 'dist'),
+      routes: ['/'],
+      renderer: new prerender.PuppeteerRenderer({
+        renderAfterElementExists: '.hero'
+      })
+    }),
   ].filter(Boolean),
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- import Hero component in App routes
- render hero + index on '/' route
- include hydrateRoot on client
- add `.hero` root class to Hero section
- setup vite-plugin-prerender configuration with PuppeteerRenderer

## Testing
- `npm run build` *(fails: `[vite-plugin-prerender] Unable to prerender all routes!`)*

------
https://chatgpt.com/codex/tasks/task_e_6840b14885088320a8cf8bf5a547c403