### PR TITLE
Add IBGE autocomplete for city field

### DIFF
--- a/src/components/form/CityField.tsx
+++ b/src/components/form/CityField.tsx
@@ -1,7 +1,7 @@
-
-import React from 'react';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import React, { useEffect, useState } from 'react';
+import { Input } from '@/components/ui/input';
 import { MapPin } from 'lucide-react';
+import { fetchCities, City } from '@/services/ibgeApi';
 
 interface CityFieldProps {
   value: string;
@@ -9,6 +9,23 @@ interface CityFieldProps {
 }
 
 const CityField: React.FC<CityFieldProps> = ({ value, onChange }) => {
+  const [options, setOptions] = useState<City[]>([]);
+
+  useEffect(() => {
+    if (value.trim().length < 2) {
+      setOptions([]);
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      fetchCities(value)
+        .then(setOptions)
+        .catch(() => setOptions([]));
+    }, 300);
+
+    return () => clearTimeout(timeout);
+  }, [value]);
+
   return (
     <div className="flex items-start gap-2">
       <div className="bg-libra-light p-1.5 rounded-full mt-0.5">
@@ -18,17 +35,21 @@ const CityField: React.FC<CityFieldProps> = ({ value, onChange }) => {
         <label className="block text-xs font-medium text-libra-navy mb-1">
           Selecione a cidade do imóvel a ser dado de garantia
         </label>
-        <Select value={value} onValueChange={onChange}>
-          <SelectTrigger className="text-sm">
-            <SelectValue placeholder="Cidade/UF do imóvel a ser dado em Garantia" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="ribeirao-preto-sp">Ribeirão Preto/SP</SelectItem>
-            <SelectItem value="sao-paulo-sp">São Paulo/SP</SelectItem>
-            <SelectItem value="campinas-sp">Campinas/SP</SelectItem>
-            <SelectItem value="santos-sp">Santos/SP</SelectItem>
-          </SelectContent>
-        </Select>
+        <Input
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="Cidade/UF do imóvel a ser dado em Garantia"
+          list="city-options"
+          className="text-sm"
+        />
+        <datalist id="city-options">
+          {options.map((city) => (
+            <option
+              key={city.id}
+              value={`${city.nome}/${city.microrregiao.mesorregiao.UF.sigla}`}
+            />
+          ))}
+        </datalist>
       </div>
     </div>
   );

--- a/src/services/ibgeApi.ts
+++ b/src/services/ibgeApi.ts
@@ -1,0 +1,21 @@
+export interface City {
+  id: number;
+  nome: string;
+  microrregiao: {
+    mesorregiao: {
+      UF: {
+        sigla: string;
+      };
+    };
+  };
+}
+
+export const fetchCities = async (query: string): Promise<City[]> => {
+  if (!query) return [];
+  const url = `https://servicodados.ibge.gov.br/api/v1/localidades/municipios?nome=${encodeURIComponent(query)}`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error('Erro ao buscar cidades');
+  }
+  return response.json();
+};

--- a/src/services/ibgeApi.ts
+++ b/src/services/ibgeApi.ts
@@ -17,5 +17,9 @@ export const fetchCities = async (query: string): Promise<City[]> => {
   if (!response.ok) {
     throw new Error('Erro ao buscar cidades');
   }
-  return response.json();
+  const data: City[] = await response.json();
+  // A API retorna todas as cidades correspondentes, que podem ser mais de 5 mil
+  // Entradas. Para evitar travamentos no navegador, limitamos as primeiras 20
+  // opções.
+  return data.slice(0, 20);
 };


### PR DESCRIPTION
## Summary
- connect the city field to IBGE API
- fetch suggestions as the user types

## Testing
- `npm install`
- `npm run lint` *(fails: 7 errors, 14 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6841d31cc0f88320a8c29fd938fc2fc7