### PR TITLE
Add city field to simulation payload

### DIFF
--- a/src/components/SimulationForm.tsx
+++ b/src/components/SimulationForm.tsx
@@ -97,7 +97,8 @@ const SimulationForm: React.FC = () => {
         numero_parcelas: parcelas,
         amortizacao: amortizacao,
         juros: 1.19,
-        carencia: 1
+        carencia: 1,
+        cidade: cidade
       };
 
       console.log('Enviando payload:', payload);

--- a/src/services/simulationApi.ts
+++ b/src/services/simulationApi.ts
@@ -18,6 +18,7 @@ export interface SimulationPayload {
   amortizacao: string;
   juros: number;
   carencia: number;
+  cidade: string;
 }
 
 /**
@@ -74,7 +75,8 @@ export const simulateCredit = async (payload: SimulationPayload): Promise<Simula
     juros: Number(payload.juros),
     numero_parcelas: Number(payload.numero_parcelas),
     carencia: Number(payload.carencia),
-    amortizacao: payload.amortizacao
+    amortizacao: payload.amortizacao,
+    cidade: payload.cidade
   };
 
   console.log('Dados formatados para envio:', formattedData);


### PR DESCRIPTION
## Summary
- include city info when building payload in `SimulationForm`
- update `SimulationPayload` interface
- send `cidade` in formatted API data

## Testing
- `npm run lint` *(fails: several lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684201a3216c83209f7880246e2bca4c