### PR TITLE
Handle API message responses in simulation

### DIFF
--- a/src/components/SimulationForm.tsx
+++ b/src/components/SimulationForm.tsx
@@ -106,6 +106,12 @@ const SimulationForm: React.FC = () => {
 
       console.log('Resposta recebida:', data);
 
+      // Se a API retornar um objeto contendo apenas { mensagem }
+      if ('mensagem' in data) {
+        setErro(data.mensagem);
+        return;
+      }
+
       // Verificar se a resposta tem dados válidos
       if (!data || !data.parcelas || !Array.isArray(data.parcelas) || data.parcelas.length === 0) {
         console.error('Estrutura de resposta inválida:', data);
@@ -188,6 +194,9 @@ const SimulationForm: React.FC = () => {
         </CardHeader>
         
         <CardContent className="p-3 md:p-4">
+          {erro && (
+            <div className="text-red-500 text-center text-xs mb-2">{erro}</div>
+          )}
           {!resultado ? (
             <form onSubmit={handleSubmit} className="space-y-2">
               
@@ -236,12 +245,6 @@ const SimulationForm: React.FC = () => {
                   LIMPAR
                 </Button>
               </div>
-
-              {erro && (
-                <div className="text-red-500 text-center text-xs mt-2">
-                  {erro}
-                </div>
-              )}
             </form>
           ) : (
             <ContactForm simulationResult={resultado} />

--- a/src/services/simulationApi.ts
+++ b/src/services/simulationApi.ts
@@ -92,16 +92,16 @@ export const simulateCredit = async (payload: SimulationPayload): Promise<Simula
       body: JSON.stringify(formattedData)
     });
 
-    if (!response.ok) {
-      throw new Error(`Erro HTTP ${response.status}: ${response.statusText}`);
-    }
-
     const data = await response.json();
     console.log('Resposta completa da API:', JSON.stringify(data, null, 2));
 
     // Se a API retornou apenas { mensagem: "texto de erro" }
     if (data && typeof data === 'object' && 'mensagem' in data && Object.keys(data).length === 1) {
       return { mensagem: data.mensagem } as SimulationError;
+    }
+
+    if (!response.ok) {
+      throw new Error(`Erro HTTP ${response.status}: ${response.statusText}`);
     }
 
     const resultadoFormatado: SimulationResponse = {

--- a/src/services/simulationApi.ts
+++ b/src/services/simulationApi.ts
@@ -40,6 +40,10 @@ export interface SimulationResponse {
   parcelas: ParcelaItem[];
 }
 
+export interface SimulationError {
+  mensagem: string;
+}
+
 /**
  * Realiza simulação de crédito com garantia de imóvel
  * 
@@ -64,7 +68,7 @@ export interface SimulationResponse {
  * });
  * ```
  */
-export const simulateCredit = async (payload: SimulationPayload): Promise<SimulationResponse> => {
+export const simulateCredit = async (payload: SimulationPayload): Promise<SimulationResponse | SimulationError> => {
   console.log('Payload enviado:', payload);
   
   // Formatar dados como números simples, não strings
@@ -94,8 +98,17 @@ export const simulateCredit = async (payload: SimulationPayload): Promise<Simula
 
     const data = await response.json();
     console.log('Resposta completa da API:', JSON.stringify(data, null, 2));
-    
-    return data;
+
+    // Se a API retornou apenas { mensagem: "texto de erro" }
+    if (data && typeof data === 'object' && 'mensagem' in data && Object.keys(data).length === 1) {
+      return { mensagem: data.mensagem } as SimulationError;
+    }
+
+    const resultadoFormatado: SimulationResponse = {
+      parcelas: data.parcelas
+    };
+
+    return resultadoFormatado;
   } catch (error) {
     console.error('Erro na chamada da API:', error);
     throw error;


### PR DESCRIPTION
## Summary
- check for API message in `simulateCredit`
- handle `mensagem` in `SimulationForm` submit
- show error message block above results

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6842057764b8832092c1888c54c9f17a