### PR TITLE
Reduce desktop header size

### DIFF
--- a/src/components/DesktopHeader.tsx
+++ b/src/components/DesktopHeader.tsx
@@ -69,7 +69,7 @@ const DesktopHeader: React.FC<DesktopHeaderProps> = ({ onPortalClientes, onSimul
         {/* Faixa principal */}
         <div className="border-b border-gray-100">
         <div className="container mx-auto px-4">
-          <div className="flex items-center justify-between h-16 lg:h-20">
+          <div className="flex items-center justify-between h-[58px] lg:h-[72px]">
             {/* Logo e slogan */}
             <div className="flex items-center gap-6">
               <Link to="/" className="flex items-center">
@@ -94,7 +94,7 @@ const DesktopHeader: React.FC<DesktopHeaderProps> = ({ onPortalClientes, onSimul
                 <Link
                   key={item.path}
                   to={item.path}
-                  className={`relative text-base lg:text-lg xl:text-xl font-medium transition-all duration-200 hover:text-libra-blue ${
+                  className={`relative text-[0.9rem] lg:text-[1.0125rem] xl:text-[1.125rem] font-medium transition-all duration-200 hover:text-libra-blue ${
                     location.pathname === item.path 
                       ? 'text-libra-blue after:absolute after:bottom-[-24px] after:left-0 after:w-full after:h-0.5 after:bg-libra-blue' 
                       : 'text-libra-navy hover:text-libra-blue'


### PR DESCRIPTION
## Summary
- reduce the desktop header height by 10%
- shrink navigation text size

## Testing
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_685bfff1bb9483208dc5ef9dca490cf7