### PR TITLE
Adjust desktop header layout

### DIFF
--- a/src/components/DesktopHeader.tsx
+++ b/src/components/DesktopHeader.tsx
@@ -69,14 +69,14 @@ const DesktopHeader: React.FC<DesktopHeaderProps> = ({ onPortalClientes, onSimul
         {/* Faixa principal */}
         <div className="border-b border-gray-100">
         <div className="container mx-auto px-4">
-          <div className="flex items-center justify-between h-[58px] lg:h-[72px]">
+          <div className="relative flex items-center h-[52px] lg:h-[65px]">
             {/* Logo e slogan */}
             <div className="flex items-center gap-6">
               <Link to="/" className="flex items-center">
-                <div className="h-10 lg:h-12 overflow-hidden flex items-center">
-                  <ImageOptimizer 
-                    src="/images/logos/libra-logo.png" 
-                    alt="Libra Crédito" 
+                <div className="h-9 lg:h-11 overflow-hidden flex items-center">
+                  <ImageOptimizer
+                    src="/images/logos/libra-logo.png"
+                    alt="Libra Crédito"
                     className="h-14 lg:h-16 w-auto transform scale-110"
                     aspectRatio={1}
                     priority={true}
@@ -89,14 +89,14 @@ const DesktopHeader: React.FC<DesktopHeaderProps> = ({ onPortalClientes, onSimul
             </div>
 
             {/* Navegação */}
-            <nav className="flex items-center space-x-6 xl:space-x-10">
+            <nav className="absolute left-1/2 -translate-x-1/2 flex items-center space-x-6 xl:space-x-10">
               {navigationItems.map((item) => (
                 <Link
                   key={item.path}
                   to={item.path}
-                  className={`relative text-[0.9rem] lg:text-[1.0125rem] xl:text-[1.125rem] font-medium transition-all duration-200 hover:text-libra-blue ${
-                    location.pathname === item.path 
-                      ? 'text-libra-blue after:absolute after:bottom-[-24px] after:left-0 after:w-full after:h-0.5 after:bg-libra-blue' 
+                  className={`relative text-[0.81rem] lg:text-[0.9125rem] xl:text-[1.0125rem] font-medium transition-all duration-200 hover:text-libra-blue ${
+                    location.pathname === item.path
+                      ? 'text-libra-blue after:absolute after:bottom-[-22px] after:left-0 after:w-full after:h-0.5 after:bg-libra-blue'
                       : 'text-libra-navy hover:text-libra-blue'
                   }`}
                 >
@@ -106,7 +106,7 @@ const DesktopHeader: React.FC<DesktopHeaderProps> = ({ onPortalClientes, onSimul
             </nav>
 
             {/* Botões à direita */}
-            <div className="flex items-center gap-3 lg:gap-4">
+            <div className="flex items-center gap-3 lg:gap-4 ml-auto">
               <Button
                 variant="outline"
                 size="sm"

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -23,7 +23,7 @@ const Hero: React.FC = () => {
     if (trustbarSection) {
       // Usar valores CSS dinâmicos para offset
       const headerOffsetMobile = 96; // var(--header-offset-mobile)
-      const headerOffsetDesktop = 120; // var(--header-offset-desktop)
+      const headerOffsetDesktop = 108; // var(--header-offset-desktop)
       const isMobileScreen = window.innerWidth < 768;
       const headerOffset = isMobileScreen ? headerOffsetMobile : headerOffsetDesktop;
       

--- a/src/index.css
+++ b/src/index.css
@@ -246,9 +246,9 @@
     /* Header Heights - Calculadas com base nos componentes */
     --header-height-mobile: 80px; /* py-2 (16px) + h-16 (64px) = 80px */
     /* Altura aproximada do header em desktop */
-    --header-height-desktop: 96px;
+    --header-height-desktop: 86px;
     --header-offset-mobile: 96px; /* altura + 16px de segurança */
-    --header-offset-desktop: 112px; /* altura + 16px de segurança */
+    --header-offset-desktop: 102px; /* altura + 16px de segurança */
   }
 
 }


### PR DESCRIPTION
## Summary
- center nav links in desktop header using absolute positioning

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c06ee8d8c832098a8be33f9284994