### PR TITLE
Fix mobile wave alignment

### DIFF
--- a/src/components/MobileLayout.tsx
+++ b/src/components/MobileLayout.tsx
@@ -36,7 +36,8 @@ const MobileLayout: React.FC<MobileLayoutProps> = ({
       <main
         id="main-content"
         data-has-header={showHeader ? "true" : "false"}
-        className={`flex-1 ${showHeader && isMobile ? 'pt-16' : ''}`}
+        className="flex-1"
+        style={showHeader && isMobile ? { paddingTop: 'var(--header-height-mobile)' } : undefined}
         role="main"
         aria-label="Conteúdo principal"
       >


### PR DESCRIPTION
## Summary
- adjust `MobileLayout` to pad main content by the mobile header height

## Testing
- `npm run lint` *(fails: missing types and other lint errors)*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685c0a4cf8cc8320b75196e03a1cb2f1