### PR TITLE
Fix mobile header spacing

### DIFF
--- a/src/components/MobileLayout.tsx
+++ b/src/components/MobileLayout.tsx
@@ -36,7 +36,7 @@ const MobileLayout: React.FC<MobileLayoutProps> = ({
       <main
         id="main-content"
         data-has-header={showHeader ? "true" : "false"}
-        className={`flex-1 ${showHeader && isMobile ? 'pt-16' : ''}`}
+        className="flex-1"
         role="main"
         aria-label="Conteúdo principal"
       >

--- a/src/index.css
+++ b/src/index.css
@@ -240,11 +240,11 @@
 
     --sidebar-ring: 217.2 91.2% 59.8%;
 
-    /* Header Heights - Calculadas com base nos componentes */
-    --header-height-mobile: 80px; /* py-2 (16px) + h-16 (64px) = 80px */
+    /* Header Heights - incluem a safe area quando presente */
+    --header-height-mobile: calc(80px + var(--safe-area-top));
     /* Altura aproximada do header em desktop */
     --header-height-desktop: 86px;
-    --header-offset-mobile: 96px; /* altura + 16px de segurança */
+    --header-offset-mobile: calc(var(--header-height-mobile) + 16px);
     --header-offset-desktop: 102px; /* altura + 16px de segurança */
   }
 

--- a/src/index.css
+++ b/src/index.css
@@ -36,9 +36,6 @@
     --safe-area-left: env(safe-area-inset-left);
     --safe-area-right: env(safe-area-inset-right);
   
-  /* Mobile Header Heights - Corrigidos */
-  --mobile-header-height: 64px;
-  --mobile-header-padding: 20px;
     
     /* Performance Optimizations */
     --animation-duration: 200ms;
@@ -60,7 +57,7 @@
     
     /* Garantir espaçamento correto para conteúdo */
     main[data-has-header="true"] {
-      padding-top: calc(var(--mobile-header-height) + var(--mobile-header-padding)) !important;
+      padding-top: var(--header-height-mobile) !important;
     }
     /* Desabilitar animações complexas em mobile */
     *, *::before, *::after {


### PR DESCRIPTION
## Summary
- adjust global main padding to use `--header-height-mobile`
- clean up unused mobile header variables
- rely on CSS instead of inline padding for MobileLayout

## Testing
- `npm run lint` *(fails: cannot find package `@eslint/js`)*
- `npm run typecheck`
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c0a4cf8cc8320b75196e03a1cb2f1