### PR TITLE
Fix mobile button centering

### DIFF
--- a/src/components/Benefits.tsx
+++ b/src/components/Benefits.tsx
@@ -81,7 +81,7 @@ const Benefits: React.FC = () => {
           ))}
         </div>
         
-        <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center">
+        <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center items-center">
           <Link to="/vantagens">
             <Button 
               size={isMobile ? "default" : "lg"} 


### PR DESCRIPTION
## Summary
- center the remaining button for mobile in the Benefits section

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_685c0f9ceba48320988f21d08e39443c