### PR TITLE
Center capital giro card on Saiba Mais

### DIFF
--- a/src/components/Benefits.tsx
+++ b/src/components/Benefits.tsx
@@ -22,9 +22,17 @@ const usageOptions = [
   }
 ];
 
-const UsageCard: React.FC<{title: string, description: string, icon: React.ComponentType<any>, isMobile: boolean, onClick: () => void}> = ({ title, description, icon: IconComponent, isMobile, onClick }) => {
+const UsageCard: React.FC<{
+  title: string;
+  description: string;
+  icon: React.ComponentType<any>;
+  isMobile: boolean;
+  onClick: () => void;
+  id?: string;
+}> = ({ title, description, icon: IconComponent, isMobile, onClick, id }) => {
   return (
-    <div 
+    <div
+      id={id}
       className={`bg-white rounded-lg shadow-lg border border-gray-100 hover:shadow-xl hover:border-libra-blue/30 transition-all duration-300 cursor-pointer transform hover:scale-105 ${isMobile ? 'p-3' : 'p-4'}`}
       onClick={onClick}
       role="button"
@@ -70,8 +78,9 @@ const Benefits: React.FC = () => {
         
         <div className={`grid grid-cols-1 ${isMobile ? 'gap-4' : 'md:grid-cols-3 gap-5'} animate-slide-up max-w-6xl mx-auto mb-6`}>
           {usageOptions.map((option, index) => (
-            <UsageCard 
-              key={index} 
+            <UsageCard
+              key={index}
+              id={index === 1 ? 'capital-giro-card' : undefined}
               title={option.title}
               description={option.description}
               icon={option.icon}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -19,23 +19,20 @@ const Hero: React.FC = () => {
   };
 
   const scrollToBenefits = () => {
-    const cta = document.getElementById('benefits-cta');
-    const trustbarSection = document.getElementById('trustbar');
-    if (cta) {
-      // Usar valores CSS dinâmicos para offset
-      const headerOffsetMobile = 96; // var(--header-offset-mobile)
-      const headerOffsetDesktop = 108; // var(--header-offset-desktop)
-      const isMobileScreen = window.innerWidth < 768;
-      const headerOffset = isMobileScreen ? headerOffsetMobile : headerOffsetDesktop;
-
-      const trustbarHeight = trustbarSection ? trustbarSection.getBoundingClientRect().height : 0;
-      const elementPosition = cta.getBoundingClientRect().top;
-      const offsetPosition = elementPosition + window.pageYOffset - headerOffset - trustbarHeight;
-
-      window.scrollTo({
-        top: offsetPosition,
-        behavior: 'smooth'
-      });
+    const card = document.getElementById('capital-giro-card');
+    const trustbar = document.getElementById('trustbar');
+    if (card) {
+      const headerOffset = window.innerWidth < 768 ? 96 : 108;
+      const trustbarHeight = trustbar ? trustbar.getBoundingClientRect().height : 0;
+      const cardHeight = card.getBoundingClientRect().height;
+      const centerOffset = (window.innerHeight - cardHeight) / 2;
+      const target =
+        card.getBoundingClientRect().top +
+        window.pageYOffset -
+        headerOffset -
+        trustbarHeight -
+        centerOffset;
+      window.scrollTo({ top: target, behavior: 'smooth' });
     }
   };
 


### PR DESCRIPTION
## Summary
- add optional `id` prop to `UsageCard`
- assign `capital-giro-card` id to second card
- adjust `scrollToBenefits` to center this card

## Testing
- `npm run lint` *(fails: Unexpected any errors)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_685c29f5e97c8320a8c7bfe86d822b80