### PR TITLE
Fix header nav centering (update)

### DIFF
--- a/src/components/DesktopHeader.tsx
+++ b/src/components/DesktopHeader.tsx
@@ -69,7 +69,7 @@ const DesktopHeader: React.FC<DesktopHeaderProps> = ({ onPortalClientes, onSimul
         {/* Faixa principal */}
         <div className="border-b border-gray-100">
         <div className="container mx-auto px-4">
-          <div className="flex items-center justify-between h-[52px] lg:h-[65px]">
+          <div className="relative flex items-center justify-between h-[52px] lg:h-[65px]">
             {/* Logo e slogan */}
             <div className="flex items-center gap-6">
               <Link to="/" className="flex items-center">
@@ -89,7 +89,7 @@ const DesktopHeader: React.FC<DesktopHeaderProps> = ({ onPortalClientes, onSimul
             </div>
 
             {/* Navegação */}
-            <nav className="flex items-center space-x-6 xl:space-x-10">
+            <nav className="absolute left-1/2 -translate-x-1/2 flex items-center space-x-6 xl:space-x-10">
               {navigationItems.map((item) => (
                 <Link
                   key={item.path}


### PR DESCRIPTION
## Summary
- position the nav absolutely in DesktopHeader so links are visually centered

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_685c508b7d4c83209f9af207443e385d