### PR TITLE
Fix header nav centering

### DIFF
--- a/src/components/DesktopHeader.tsx
+++ b/src/components/DesktopHeader.tsx
@@ -89,7 +89,7 @@ const DesktopHeader: React.FC<DesktopHeaderProps> = ({ onPortalClientes, onSimul
             </div>
 
             {/* Navegação */}
-            <nav className="flex items-center space-x-6 xl:space-x-10">
+            <nav className="flex-1 flex items-center justify-center space-x-6 xl:space-x-10">
               {navigationItems.map((item) => (
                 <Link
                   key={item.path}


### PR DESCRIPTION
## Summary
- revert absolute positioning on the desktop header nav
- give the nav flex-1 and center its items

## Testing
- `npm run lint` *(fails: 63 errors)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_685c508b7d4c83209f9af207443e385d