### PR TITLE
Increase desktop logo size

### DIFF
--- a/src/components/DesktopHeader.tsx
+++ b/src/components/DesktopHeader.tsx
@@ -69,11 +69,11 @@ const DesktopHeader: React.FC<DesktopHeaderProps> = ({ onPortalClientes, onSimul
         {/* Faixa principal */}
         <div className="border-b border-gray-100">
         <div className="container mx-auto px-4">
-          <div className="flex items-center justify-between h-[52px] lg:h-[65px]">
+          <div className="flex items-center justify-between h-[52px] lg:h-[91px]">
             {/* Logo e slogan */}
             <div className="flex items-center gap-6">
               <Link to="/" className="flex items-center">
-                <div className="h-[52px] lg:h-[65px] overflow-hidden flex items-center">
+                <div className="h-[52px] lg:h-[91px] overflow-hidden flex items-center">
                   <ImageOptimizer 
                     src="/images/logos/libra-logo.png" 
                     alt="Libra Crédito - Home Equity com garantia de imóvel" 


### PR DESCRIPTION
## Summary
- increase desktop header logo height by 40%

## Testing
- `npm run lint` *(fails: many lint errors)*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685ed92778b083208ad67d535f46b46d