### PR TITLE
Improve orientation detection on iOS

### DIFF
--- a/src/components/MobileOptimized.tsx
+++ b/src/components/MobileOptimized.tsx
@@ -137,21 +137,29 @@ export const MobileOptimized: React.FC<MobileOptimizedProps> = ({ children }) =>
 
 // Hook para detectar orientação
 export const useOrientation = () => {
+  const getOrientation = () => {
+    if (window.screen && (window.screen as any).orientation) {
+      const type = (window.screen as any).orientation.type as string;
+      return type.startsWith('portrait') ? 'portrait' : 'landscape';
+    }
+    return window.matchMedia('(orientation: portrait)').matches ? 'portrait' : 'landscape';
+  };
+
   const [orientation, setOrientation] = React.useState<'portrait' | 'landscape'>(
-    window.innerHeight > window.innerWidth ? 'portrait' : 'landscape'
+    getOrientation()
   );
 
   React.useEffect(() => {
     const handleOrientationChange = () => {
-      setOrientation(window.innerHeight > window.innerWidth ? 'portrait' : 'landscape');
+      setOrientation(getOrientation());
     };
 
-    window.addEventListener('resize', handleOrientationChange);
     window.addEventListener('orientationchange', handleOrientationChange);
+    window.addEventListener('resize', handleOrientationChange);
 
     return () => {
-      window.removeEventListener('resize', handleOrientationChange);
       window.removeEventListener('orientationchange', handleOrientationChange);
+      window.removeEventListener('resize', handleOrientationChange);
     };
   }, []);
 

--- a/src/hooks/use-mobile.ts
+++ b/src/hooks/use-mobile.ts
@@ -61,14 +61,24 @@ export const useOrientation = () => {
   const [orientation, setOrientation] = useState<'portrait' | 'landscape'>('portrait');
 
   useEffect(() => {
+    const getOrientation = () => {
+      if (window.screen && (window.screen as any).orientation) {
+        const type = (window.screen as any).orientation.type as string;
+        return type.startsWith('portrait') ? 'portrait' : 'landscape';
+      }
+      return window.matchMedia('(orientation: portrait)').matches ? 'portrait' : 'landscape';
+    };
+
     const checkOrientation = () => {
-      setOrientation(window.innerHeight > window.innerWidth ? 'portrait' : 'landscape');
+      setOrientation(getOrientation());
     };
 
     checkOrientation();
+    window.addEventListener('orientationchange', checkOrientation);
     window.addEventListener('resize', checkOrientation);
 
     return () => {
+      window.removeEventListener('orientationchange', checkOrientation);
       window.removeEventListener('resize', checkOrientation);
     };
   }, []);


### PR DESCRIPTION
## Summary
- use `screen.orientation` or `matchMedia` to detect orientation
- listen to `orientationchange` and `resize` to update state

## Testing
- `npm run lint` *(fails: cannot fix all lint errors)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_685ef5627d7c8320a1bd674040d8ded8