### PR TITLE
Use Montserrat as default font

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
       body { 
         line-height: 1.5; 
         -webkit-font-smoothing: antialiased;
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+        font-family: 'Montserrat', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
         background: #ffffff;
       }
       

--- a/src/styles/critical.css
+++ b/src/styles/critical.css
@@ -3,10 +3,10 @@
 /* Reset e Base */
 *, *::before, *::after { box-sizing: border-box; }
 * { margin: 0; }
-body { 
-  line-height: 1.5; 
+body {
+  line-height: 1.5;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  font-family: 'Montserrat', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
   background-color: #ffffff;
 }
 


### PR DESCRIPTION
## Summary
- set Montserrat as the global font in `index.html`
- update `src/styles/critical.css` to use Montserrat

## Testing
- `npm run lint` *(fails: Unexpected any types)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_686570b22c5c83208dc59aed8a214644