### PR TITLE
Add BRL mask and unify icon color

### DIFF
--- a/src/components/SimulationForm.tsx
+++ b/src/components/SimulationForm.tsx
@@ -60,7 +60,7 @@ import SmartApiMessage from './messages/SmartApiMessage';
 import SimulationResultDisplay from './SimulationResultDisplay';
 import { analyzeApiMessage, ApiMessageAnalysis } from '@/utils/apiMessageAnalyzer';
 import { analyzeLocalMessage } from '@/utils/localMessageAnalyzer';
-import { formatBRL, formatBRLInput, norm } from '@/utils/formatters';
+import { formatBRL, norm } from '@/utils/formatters';
 
 const SimulationForm: React.FC = () => {
   const { sessionId, trackSimulation } = useUserJourney();
@@ -80,11 +80,11 @@ const SimulationForm: React.FC = () => {
   const validation = validateForm(emprestimo, garantia, parcelas, amortizacao, cidade);
 
   const handleEmprestimoChange = (value: string) => {
-    setEmprestimo(formatBRLInput(value));
+    setEmprestimo(formatBRL(value));
   };
 
   const handleGarantiaChange = (value: string) => {
-    setGarantia(formatBRLInput(value));
+    setGarantia(formatBRL(value));
   };
 
   // Função para rolar para o resultado no mobile
@@ -200,7 +200,7 @@ const SimulationForm: React.FC = () => {
   // Função para ajustar valores automaticamente (30%) e executar simulação
   const handleAdjustValues = async (novoEmprestimo: number, isRural: boolean = false) => {
     // Ajustar os valores - usar valor completo com formatação
-    setEmprestimo(formatBRLInput(novoEmprestimo.toString()));
+    setEmprestimo(formatBRL(novoEmprestimo.toString()));
     setIsRuralProperty(isRural);
     setApiMessage(null);
     setErro('');
@@ -215,10 +215,10 @@ const SimulationForm: React.FC = () => {
 
       // Recalcular validação com novos valores
       const newValidation = validateForm(
-        formatBRLInput(novoEmprestimo.toString()), 
-        garantia, 
-        parcelas, 
-        amortizacao, 
+        formatBRL(novoEmprestimo.toString()),
+        garantia,
+        parcelas,
+        amortizacao,
         cidade
       );
 

--- a/src/components/SimulationResultDisplay.tsx
+++ b/src/components/SimulationResultDisplay.tsx
@@ -127,7 +127,7 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
       <div className="bg-gradient-to-br from-[#003399] to-[#004080] rounded-xl p-4 text-white shadow-xl">
         {/* Header compacto */}
         <div className="flex items-center gap-2 mb-4">
-          <CheckCircle className="w-5 h-5 text-green-400" />
+          <CheckCircle className="w-5 h-5 text-green-500" />
           <div>
             <h3 className="font-bold">Simulação Pronta!</h3>
           </div>
@@ -220,7 +220,7 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
       {/* Header compacto */}
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2">
-          <CheckCircle className="w-5 h-5 text-green-400" />
+          <CheckCircle className="w-5 h-5 text-green-500" />
           <h3 className="text-lg font-bold">Simulação Pronta!</h3>
         </div>
         <Button

--- a/src/components/form/AmortizationField.tsx
+++ b/src/components/form/AmortizationField.tsx
@@ -11,7 +11,7 @@ const AmortizationField: React.FC<AmortizationFieldProps> = ({ value, onChange }
   return (
     <div className="flex items-center gap-2">
       <div className="bg-libra-light p-1.5 rounded-full flex-shrink-0">
-        <Calculator className="w-4 h-4 text-libra-blue" />
+        <Calculator className="w-4 h-4 text-green-500" />
       </div>
       <div className="flex-1">
         <label className="block text-xs font-medium text-libra-navy mb-1">
@@ -24,7 +24,7 @@ const AmortizationField: React.FC<AmortizationFieldProps> = ({ value, onChange }
               value="PRICE"
               checked={value === 'PRICE'}
               onChange={(e) => onChange(e.target.value)}
-              className="text-libra-blue"
+              className="text-green-500"
             />
             <span className="text-xs">PRICE</span>
           </label>
@@ -34,7 +34,7 @@ const AmortizationField: React.FC<AmortizationFieldProps> = ({ value, onChange }
               value="SAC"
               checked={value === 'SAC'}
               onChange={(e) => onChange(e.target.value)}
-              className="text-libra-blue"
+              className="text-green-500"
             />
             <span className="text-xs">SAC</span>
           </label>

--- a/src/components/form/CityAutocomplete.jsx
+++ b/src/components/form/CityAutocomplete.jsx
@@ -132,7 +132,7 @@ const CityAutocomplete = ({ value = '', onCityChange }) => {
     <div ref={containerRef} className="flex items-center gap-2 relative">
       {/* Icon */}
       <div className="bg-libra-light p-1.5 rounded-full flex-shrink-0">
-        <MapPin className="w-4 h-4 text-libra-blue" />
+        <MapPin className="w-4 h-4 text-green-500" />
       </div>
       <div className="flex-1 relative">
         <label className="block text-xs font-medium text-libra-navy mb-1">
@@ -150,7 +150,7 @@ const CityAutocomplete = ({ value = '', onCityChange }) => {
           placeholder={
             inputValue.length < 2 ? 'Digite 2 ou mais caracteres' : 'Busque a cidade'
           }
-          className="text-sm w-full px-3 py-2 rounded-md border-2 border-[#3CB371] focus:outline-none focus:border-[#2E8B57] transition-colors"
+          className="text-sm w-full px-3 py-2 rounded-md border-2 border-green-500 focus:outline-none focus:border-green-600 transition-colors"
         />
         
         {/* Suggestion dropdown - Fixed positioning for mobile */}
@@ -189,7 +189,7 @@ const CityAutocomplete = ({ value = '', onCityChange }) => {
                     }`}
                   >
                     <div className="flex items-center gap-2">
-                      <MapPin className="w-3 h-3 text-libra-blue flex-shrink-0" />
+                      <MapPin className="w-3 h-3 text-green-500 flex-shrink-0" />
                       <span className="truncate">{city}</span>
                     </div>
                   </li>

--- a/src/components/form/CityField.tsx
+++ b/src/components/form/CityField.tsx
@@ -12,7 +12,7 @@ const CityField: React.FC<CityFieldProps> = ({ value, onChange }) => {
   return (
     <div className="flex items-start gap-2">
       <div className="bg-libra-light p-1.5 rounded-full mt-0.5">
-        <MapPin className="w-4 h-4 text-libra-blue" />
+        <MapPin className="w-4 h-4 text-green-500" />
       </div>
       <div className="flex-1">
         <label className="block text-xs font-medium text-libra-navy mb-1">

--- a/src/components/form/GuaranteeAmountField.tsx
+++ b/src/components/form/GuaranteeAmountField.tsx
@@ -17,7 +17,7 @@ const GuaranteeAmountField: React.FC<GuaranteeAmountFieldProps> = ({
   return (
     <div className="flex items-center gap-2">
       <div className="bg-libra-light p-1.5 rounded-full flex-shrink-0">
-        <Home className="w-4 h-4 text-libra-blue" />
+        <Home className="w-4 h-4 text-green-500" />
       </div>
       <div className="flex-1">
         <label className="block text-xs font-medium text-libra-navy mb-1">
@@ -27,7 +27,7 @@ const GuaranteeAmountField: React.FC<GuaranteeAmountFieldProps> = ({
           <Input
             value={value}
             onChange={(e) => onChange(e.target.value)}
-            placeholder="600000"
+            placeholder="R$ 600.000"
             className="text-sm"
             inputMode="numeric"
           />

--- a/src/components/form/InstallmentsField.tsx
+++ b/src/components/form/InstallmentsField.tsx
@@ -11,7 +11,7 @@ const InstallmentsField: React.FC<InstallmentsFieldProps> = ({ value, onChange }
   return (
     <div className="flex items-center gap-2">
       <div className="bg-libra-light p-1.5 rounded-full flex-shrink-0">
-        <Calendar className="w-4 h-4 text-libra-blue" />
+        <Calendar className="w-4 h-4 text-green-500" />
       </div>
       <div className="flex-1">
         <div className="flex items-center justify-between mb-1">

--- a/src/components/form/LoanAmountField.tsx
+++ b/src/components/form/LoanAmountField.tsx
@@ -12,7 +12,7 @@ const LoanAmountField: React.FC<LoanAmountFieldProps> = ({ value, onChange }) =>
   return (
     <div className="flex items-center gap-2">
       <div className="bg-libra-light p-1.5 rounded-full flex-shrink-0">
-        <DollarSign className="w-4 h-4 text-libra-blue" />
+        <DollarSign className="w-4 h-4 text-green-500" />
       </div>
       <div className="flex-1">
         <label className="block text-xs font-medium text-libra-navy mb-1">
@@ -22,7 +22,7 @@ const LoanAmountField: React.FC<LoanAmountFieldProps> = ({ value, onChange }) =>
           <Input
             value={value}
             onChange={(e) => onChange(e.target.value)}
-            placeholder="300000"
+            placeholder="R$ 300.000"
             className="text-sm"
             inputMode="numeric"
           />


### PR DESCRIPTION
## Summary
- use green icon color across form components
- display BRL mask in simulation form fields
- update simulation result icons to use green
- tweak city autocomplete styling

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' and other lint errors)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68658e7cbf908320893bff0fdf76921f