### PR TITLE
Add BRL mask and unify icon color

### DIFF
--- a/src/components/LocalSimulationForm.tsx
+++ b/src/components/LocalSimulationForm.tsx
@@ -331,7 +331,7 @@ const LocalSimulationForm: React.FC = () => {
                 <Button
                   onClick={handleCalculate}
                   disabled={!canCalculate() || loading}
-                  className="flex-1 bg-libra-blue hover:bg-libra-blue/90 text-white py-2 text-sm font-semibold min-h-[44px]"
+                  className="flex-1 bg-green-500 hover:bg-green-600 text-white py-2 text-sm font-semibold min-h-[44px]"
                 >
                   {loading ? (
                     <div className="flex items-center gap-2">
@@ -346,7 +346,7 @@ const LocalSimulationForm: React.FC = () => {
                   type="button"
                   variant="outline"
                   onClick={handleClear}
-                  className="px-4 py-2 text-libra-blue border-libra-blue hover:bg-libra-light min-h-[44px] text-sm"
+                  className="px-4 py-2 text-green-500 border-green-500 hover:bg-green-50 min-h-[44px] text-sm"
                 >
                   LIMPAR
                 </Button>

--- a/src/components/SimulationForm.tsx
+++ b/src/components/SimulationForm.tsx
@@ -60,7 +60,7 @@ import SmartApiMessage from './messages/SmartApiMessage';
 import SimulationResultDisplay from './SimulationResultDisplay';
 import { analyzeApiMessage, ApiMessageAnalysis } from '@/utils/apiMessageAnalyzer';
 import { analyzeLocalMessage } from '@/utils/localMessageAnalyzer';
-import { formatBRL, formatBRLInput, norm } from '@/utils/formatters';
+import { formatBRL, norm } from '@/utils/formatters';
 
 const SimulationForm: React.FC = () => {
   const { sessionId, trackSimulation } = useUserJourney();
@@ -80,11 +80,11 @@ const SimulationForm: React.FC = () => {
   const validation = validateForm(emprestimo, garantia, parcelas, amortizacao, cidade);
 
   const handleEmprestimoChange = (value: string) => {
-    setEmprestimo(formatBRLInput(value));
+    setEmprestimo(formatBRL(value));
   };
 
   const handleGarantiaChange = (value: string) => {
-    setGarantia(formatBRLInput(value));
+    setGarantia(formatBRL(value));
   };
 
   // Função para rolar para o resultado no mobile
@@ -200,7 +200,7 @@ const SimulationForm: React.FC = () => {
   // Função para ajustar valores automaticamente (30%) e executar simulação
   const handleAdjustValues = async (novoEmprestimo: number, isRural: boolean = false) => {
     // Ajustar os valores - usar valor completo com formatação
-    setEmprestimo(formatBRLInput(novoEmprestimo.toString()));
+    setEmprestimo(formatBRL(novoEmprestimo.toString()));
     setIsRuralProperty(isRural);
     setApiMessage(null);
     setErro('');
@@ -215,10 +215,10 @@ const SimulationForm: React.FC = () => {
 
       // Recalcular validação com novos valores
       const newValidation = validateForm(
-        formatBRLInput(novoEmprestimo.toString()), 
-        garantia, 
-        parcelas, 
-        amortizacao, 
+        formatBRL(novoEmprestimo.toString()),
+        garantia,
+        parcelas,
+        amortizacao,
         cidade
       );
 
@@ -420,7 +420,7 @@ const SimulationForm: React.FC = () => {
                 <Button
                 type="submit"
                 disabled={!validation.formularioValido || loading}
-                className="flex-1 bg-libra-blue hover:bg-libra-blue/90 text-white py-2 text-sm font-semibold min-h-[44px]"
+                className="flex-1 bg-green-500 hover:bg-green-600 text-white py-2 text-sm font-semibold min-h-[44px]"
                 >
                   {loading ? (
                     <div className="flex items-center gap-2">
@@ -435,7 +435,7 @@ const SimulationForm: React.FC = () => {
                   type="button"
                   variant="outline"
                   onClick={handleClear}
-                  className="px-4 py-2 text-libra-blue border-libra-blue hover:bg-libra-light min-h-[44px] text-sm"
+                  className="px-4 py-2 text-green-500 border-green-500 hover:bg-green-50 min-h-[44px] text-sm"
                 >
                   LIMPAR
                 </Button>

--- a/src/components/SimulationResultDisplay.tsx
+++ b/src/components/SimulationResultDisplay.tsx
@@ -127,9 +127,9 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
       <div className="bg-gradient-to-br from-[#003399] to-[#004080] rounded-xl p-4 text-white shadow-xl">
         {/* Header compacto */}
         <div className="flex items-center gap-2 mb-4">
-          <CheckCircle className="w-5 h-5 text-green-400" />
+          <CheckCircle className="w-5 h-5 text-green-500" />
           <div>
-            <h3 className="font-bold">Simulação Pronta!</h3>
+            <h3 className="font-bold text-green-500">Simulação Pronta!</h3>
           </div>
         </div>
 
@@ -140,16 +140,16 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
               <div className="text-xs text-libra-navy mb-3 text-center">Sistema SAC - Parcelas Decrescentes</div>
               <div className="grid grid-cols-2 gap-3">
                 {/* Primeira parcela - destaque maior */}
-                <div className="text-center bg-libra-light rounded-lg p-3 border-2 border-libra-blue/30">
-                  <div className="text-xs font-medium text-libra-blue mb-1">1ª Parcela</div>
+                <div className="text-center bg-libra-light rounded-lg p-3 border-2 border-green-500/30">
+                  <div className="text-xs font-medium text-green-500 mb-1">1ª Parcela</div>
                   <div className="text-lg font-bold text-libra-navy">
                     R$ {primeiraParcela.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}
                   </div>
                   <div className="text-xs text-gray-600 mt-1">Maior valor</div>
                 </div>
                 {/* Última parcela */}
-                <div className="text-center bg-libra-light rounded-lg p-3 border border-libra-blue/20">
-                  <div className="text-xs font-medium text-libra-blue mb-1">Última</div>
+                <div className="text-center bg-libra-light rounded-lg p-3 border border-green-500/20">
+                  <div className="text-xs font-medium text-green-500 mb-1">Última</div>
                   <div className="text-base font-bold text-libra-navy">
                     R$ {ultimaParcela?.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}
                   </div>
@@ -208,7 +208,7 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
           compact={true}
           className="space-y-3"
           inputClassName="bg-white/90 text-gray-800 placeholder-gray-500"
-          buttonClassName="bg-white text-libra-navy hover:bg-gray-100 font-bold py-3 w-full"
+          buttonClassName="bg-green-500 text-white hover:bg-green-600 font-bold py-3 w-full"
         />
       </div>
     );
@@ -220,13 +220,13 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
       {/* Header compacto */}
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2">
-          <CheckCircle className="w-5 h-5 text-green-400" />
-          <h3 className="text-lg font-bold">Simulação Pronta!</h3>
+          <CheckCircle className="w-5 h-5 text-green-500" />
+          <h3 className="text-lg font-bold text-green-500">Simulação Pronta!</h3>
         </div>
         <Button
           onClick={onNewSimulation}
           variant="outline"
-          className="bg-white/10 border-white/30 text-white hover:bg-white/20 text-xs px-3 py-2"
+          className="bg-green-500 border-green-600 text-white hover:bg-green-600 text-xs px-3 py-2"
           size="sm"
         >
           <Calculator className="w-3 h-3 mr-1" />
@@ -241,23 +241,23 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
             <div className="text-xs text-libra-navy mb-2 text-center">Sistema SAC - Parcelas Decrescentes</div>
             <div className="grid grid-cols-3 gap-2">
               {/* Primeira parcela */}
-              <div className="text-center bg-libra-light rounded-lg p-2 border border-libra-blue/30">
-                <div className="text-xs font-medium text-libra-blue mb-1">1ª Parcela</div>
+              <div className="text-center bg-libra-light rounded-lg p-2 border border-green-500/30">
+                <div className="text-xs font-medium text-green-500 mb-1">1ª Parcela</div>
                 <div className="text-lg font-bold text-libra-navy">
                   R$ {primeiraParcela.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}
                 </div>
                 <div className="text-xs text-gray-600">Maior valor</div>
               </div>
               {/* Última parcela */}
-              <div className="text-center bg-libra-light rounded-lg p-2 border border-libra-blue/20">
-                <div className="text-xs font-medium text-libra-blue mb-1">Última Parcela</div>
+              <div className="text-center bg-libra-light rounded-lg p-2 border border-green-500/20">
+                <div className="text-xs font-medium text-green-500 mb-1">Última Parcela</div>
                 <div className="text-base font-bold text-libra-navy">
                   R$ {ultimaParcela?.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}
                 </div>
                 <div className="text-xs text-gray-600">Menor valor</div>
               </div>
               {/* Renda mínima */}
-              <div className="text-center rounded-lg p-2 border border-libra-blue/20">
+              <div className="text-center rounded-lg p-2 border border-green-500/20">
                 <div className="text-xs text-gray-600 mb-1 flex items-center justify-center gap-1">
                   <span>Renda necessária</span>
                   <TooltipInfo content="Renda familiar podendo ser composta por até 4 pessoas">
@@ -323,7 +323,7 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
         compact={true}
         className="space-y-3"
         inputClassName="bg-white/90 text-gray-800 placeholder-gray-500"
-        buttonClassName="bg-white text-libra-navy hover:bg-gray-100 font-bold py-3 w-full"
+        buttonClassName="bg-green-500 text-white hover:bg-green-600 font-bold py-3 w-full"
       />
     </div>
   );

--- a/src/components/form/AmortizationField.tsx
+++ b/src/components/form/AmortizationField.tsx
@@ -11,7 +11,7 @@ const AmortizationField: React.FC<AmortizationFieldProps> = ({ value, onChange }
   return (
     <div className="flex items-center gap-2">
       <div className="bg-libra-light p-1.5 rounded-full flex-shrink-0">
-        <Calculator className="w-4 h-4 text-libra-blue" />
+        <Calculator className="w-4 h-4 text-green-500" />
       </div>
       <div className="flex-1">
         <label className="block text-xs font-medium text-libra-navy mb-1">
@@ -24,7 +24,7 @@ const AmortizationField: React.FC<AmortizationFieldProps> = ({ value, onChange }
               value="PRICE"
               checked={value === 'PRICE'}
               onChange={(e) => onChange(e.target.value)}
-              className="text-libra-blue"
+              className="text-green-500"
             />
             <span className="text-xs">PRICE</span>
           </label>
@@ -34,7 +34,7 @@ const AmortizationField: React.FC<AmortizationFieldProps> = ({ value, onChange }
               value="SAC"
               checked={value === 'SAC'}
               onChange={(e) => onChange(e.target.value)}
-              className="text-libra-blue"
+              className="text-green-500"
             />
             <span className="text-xs">SAC</span>
           </label>

--- a/src/components/form/CityAutocomplete.jsx
+++ b/src/components/form/CityAutocomplete.jsx
@@ -132,7 +132,7 @@ const CityAutocomplete = ({ value = '', onCityChange }) => {
     <div ref={containerRef} className="flex items-center gap-2 relative">
       {/* Icon */}
       <div className="bg-libra-light p-1.5 rounded-full flex-shrink-0">
-        <MapPin className="w-4 h-4 text-libra-blue" />
+        <MapPin className="w-4 h-4 text-green-500" />
       </div>
       <div className="flex-1 relative">
         <label className="block text-xs font-medium text-libra-navy mb-1">
@@ -150,7 +150,7 @@ const CityAutocomplete = ({ value = '', onCityChange }) => {
           placeholder={
             inputValue.length < 2 ? 'Digite 2 ou mais caracteres' : 'Busque a cidade'
           }
-          className="text-sm w-full px-3 py-2 rounded-md border-2 border-[#3CB371] focus:outline-none focus:border-[#2E8B57] transition-colors"
+          className="text-sm w-full px-3 py-2 rounded-md border-2 border-green-500 focus:outline-none focus:border-green-600 transition-colors"
         />
         
         {/* Suggestion dropdown - Fixed positioning for mobile */}
@@ -160,7 +160,7 @@ const CityAutocomplete = ({ value = '', onCityChange }) => {
               {isLoading && (
                 <li className="px-3 py-2 text-center text-gray-500">
                   <div className="flex items-center justify-center gap-2">
-                    <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-libra-blue"></div>
+                    <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-green-500"></div>
                     Buscando...
                   </div>
                 </li>
@@ -189,7 +189,7 @@ const CityAutocomplete = ({ value = '', onCityChange }) => {
                     }`}
                   >
                     <div className="flex items-center gap-2">
-                      <MapPin className="w-3 h-3 text-libra-blue flex-shrink-0" />
+                      <MapPin className="w-3 h-3 text-green-500 flex-shrink-0" />
                       <span className="truncate">{city}</span>
                     </div>
                   </li>

--- a/src/components/form/CityField.tsx
+++ b/src/components/form/CityField.tsx
@@ -12,7 +12,7 @@ const CityField: React.FC<CityFieldProps> = ({ value, onChange }) => {
   return (
     <div className="flex items-start gap-2">
       <div className="bg-libra-light p-1.5 rounded-full mt-0.5">
-        <MapPin className="w-4 h-4 text-libra-blue" />
+        <MapPin className="w-4 h-4 text-green-500" />
       </div>
       <div className="flex-1">
         <label className="block text-xs font-medium text-libra-navy mb-1">

--- a/src/components/form/GuaranteeAmountField.tsx
+++ b/src/components/form/GuaranteeAmountField.tsx
@@ -17,7 +17,7 @@ const GuaranteeAmountField: React.FC<GuaranteeAmountFieldProps> = ({
   return (
     <div className="flex items-center gap-2">
       <div className="bg-libra-light p-1.5 rounded-full flex-shrink-0">
-        <Home className="w-4 h-4 text-libra-blue" />
+        <Home className="w-4 h-4 text-green-500" />
       </div>
       <div className="flex-1">
         <label className="block text-xs font-medium text-libra-navy mb-1">
@@ -27,7 +27,7 @@ const GuaranteeAmountField: React.FC<GuaranteeAmountFieldProps> = ({
           <Input
             value={value}
             onChange={(e) => onChange(e.target.value)}
-            placeholder="600000"
+            placeholder="R$ 600.000"
             className="text-sm"
             inputMode="numeric"
           />

--- a/src/components/form/InstallmentsField.tsx
+++ b/src/components/form/InstallmentsField.tsx
@@ -11,14 +11,14 @@ const InstallmentsField: React.FC<InstallmentsFieldProps> = ({ value, onChange }
   return (
     <div className="flex items-center gap-2">
       <div className="bg-libra-light p-1.5 rounded-full flex-shrink-0">
-        <Calendar className="w-4 h-4 text-libra-blue" />
+        <Calendar className="w-4 h-4 text-green-500" />
       </div>
       <div className="flex-1">
         <div className="flex items-center justify-between mb-1">
           <label className="text-xs font-medium text-libra-navy">
             Em quantas parcelas?
           </label>
-          <span className="bg-libra-blue text-white px-2 py-0.5 rounded text-xs font-bold">
+          <span className="bg-green-500 text-white px-2 py-0.5 rounded text-xs font-bold">
             {value} meses ({Math.round(value / 12)} anos)
           </span>
         </div>

--- a/src/components/form/LoanAmountField.tsx
+++ b/src/components/form/LoanAmountField.tsx
@@ -12,7 +12,7 @@ const LoanAmountField: React.FC<LoanAmountFieldProps> = ({ value, onChange }) =>
   return (
     <div className="flex items-center gap-2">
       <div className="bg-libra-light p-1.5 rounded-full flex-shrink-0">
-        <DollarSign className="w-4 h-4 text-libra-blue" />
+        <DollarSign className="w-4 h-4 text-green-500" />
       </div>
       <div className="flex-1">
         <label className="block text-xs font-medium text-libra-navy mb-1">
@@ -22,7 +22,7 @@ const LoanAmountField: React.FC<LoanAmountFieldProps> = ({ value, onChange }) =>
           <Input
             value={value}
             onChange={(e) => onChange(e.target.value)}
-            placeholder="300000"
+            placeholder="R$ 300.000"
             className="text-sm"
             inputMode="numeric"
           />


### PR DESCRIPTION
## Summary
- use green icon color across form components
- display BRL mask in simulation form fields
- update simulation result icons to use green
- tweak city autocomplete styling
- turn simulation buttons and texts green

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68658e7cbf908320893bff0fdf76921f