### PR TITLE
Update simulation styling

### DIFF
--- a/src/components/SimulationForm.tsx
+++ b/src/components/SimulationForm.tsx
@@ -390,7 +390,7 @@ const SimulationForm: React.FC = () => {
         {/* Formulário de Simulação */}
         <Card className="shadow-lg">
           <CardHeader className="text-center pb-2">
-            <CardTitle className="text-lg md:text-xl font-bold text-libra-navy mb-1">
+            <CardTitle className="text-lg md:text-xl font-bold text-green-500 mb-1">
               Sua simulação em um clique!
             </CardTitle>
             <p className="text-gray-600 text-xs">
@@ -420,7 +420,7 @@ const SimulationForm: React.FC = () => {
                 <Button
                 type="submit"
                 disabled={!validation.formularioValido || loading}
-                className="flex-1 bg-libra-blue hover:bg-libra-blue/90 text-white py-2 text-sm font-semibold min-h-[44px]"
+                className="flex-1 bg-green-500 hover:bg-green-600 text-white py-2 text-sm font-semibold min-h-[44px]"
                 >
                   {loading ? (
                     <div className="flex items-center gap-2">

--- a/src/components/SimulationResultDisplay.tsx
+++ b/src/components/SimulationResultDisplay.tsx
@@ -124,9 +124,9 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
   if (isMobile) {
     // Layout Mobile - Sucinto e direto
     return (
-      <div className="bg-gradient-to-br from-[#003399] to-[#004080] rounded-xl p-4 text-white shadow-xl">
+      <div className="bg-green-600 rounded-xl p-4 text-libra-navy shadow-xl">
         {/* Header compacto */}
-        <div className="flex items-center gap-2 mb-4 text-green-600">
+        <div className="flex items-center gap-2 mb-4">
           <CheckCircle className="w-5 h-5 text-green-600" />
           <div>
             <h3 className="font-bold">Simulação Pronta!</h3>
@@ -216,10 +216,10 @@ const SimulationResultDisplay: React.FC<SimulationResultDisplayProps> = ({
   
   // Layout Desktop - Adaptação do Mobile na Lateral
   return (
-    <div className="bg-gradient-to-br from-[#003399] to-[#004080] rounded-xl p-4 text-white shadow-xl">
+    <div className="bg-green-600 rounded-xl p-4 text-libra-navy shadow-xl">
       {/* Header compacto */}
       <div className="flex items-center justify-between mb-3">
-        <div className="flex items-center gap-2 text-green-600">
+      <div className="flex items-center gap-2">
           <CheckCircle className="w-5 h-5 text-green-600" />
           <h3 className="text-lg font-bold">Simulação Pronta!</h3>
         </div>

--- a/src/components/form/AmortizationField.tsx
+++ b/src/components/form/AmortizationField.tsx
@@ -14,7 +14,7 @@ const AmortizationField: React.FC<AmortizationFieldProps> = ({ value, onChange }
         <Calculator className="w-4 h-4 text-green-500" />
       </div>
       <div className="flex-1">
-        <label className="block text-xs font-medium text-libra-navy mb-1">
+        <label className="block text-xs font-medium text-green-500 mb-1">
           Escolha a Amortização
         </label>
         <div className="flex gap-4">

--- a/src/components/form/CityAutocomplete.jsx
+++ b/src/components/form/CityAutocomplete.jsx
@@ -135,7 +135,7 @@ const CityAutocomplete = ({ value = '', onCityChange }) => {
         <MapPin className="w-4 h-4 text-green-500" />
       </div>
       <div className="flex-1 relative">
-        <label className="block text-xs font-medium text-libra-navy mb-1">
+        <label className="block text-xs font-medium text-green-500 mb-1">
           Selecione a cidade do imóvel a ser dado de garantia
         </label>
         {/* Input with green border */}

--- a/src/components/form/GuaranteeAmountField.tsx
+++ b/src/components/form/GuaranteeAmountField.tsx
@@ -20,7 +20,7 @@ const GuaranteeAmountField: React.FC<GuaranteeAmountFieldProps> = ({
         <Home className="w-4 h-4 text-green-500" />
       </div>
       <div className="flex-1">
-        <label className="block text-xs font-medium text-libra-navy mb-1">
+        <label className="block text-xs font-medium text-green-500 mb-1">
           Digite o valor do Imóvel em Garantia
         </label>
         <div className="relative">

--- a/src/components/form/InstallmentsField.tsx
+++ b/src/components/form/InstallmentsField.tsx
@@ -15,7 +15,7 @@ const InstallmentsField: React.FC<InstallmentsFieldProps> = ({ value, onChange }
       </div>
       <div className="flex-1">
         <div className="flex items-center justify-between mb-1">
-          <label className="text-xs font-medium text-libra-navy">
+          <label className="text-xs font-medium text-green-500">
             Em quantas parcelas?
           </label>
           <span className="bg-libra-blue text-white px-2 py-0.5 rounded text-xs font-bold">

--- a/src/components/form/LoanAmountField.tsx
+++ b/src/components/form/LoanAmountField.tsx
@@ -15,7 +15,7 @@ const LoanAmountField: React.FC<LoanAmountFieldProps> = ({ value, onChange }) =>
         <DollarSign className="w-4 h-4 text-green-500" />
       </div>
       <div className="flex-1">
-        <label className="block text-xs font-medium text-libra-navy mb-1">
+        <label className="block text-xs font-medium text-green-500 mb-1">
           Digite o valor desejado do Empréstimo
         </label>
         <div className="relative">


### PR DESCRIPTION
## Summary
- turn form labels green and highlight the section title
- color the calculate button green
- display simulation results card with green background and blue text

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68659a5917e48320b31d5765a0cebb0b