### PR TITLE
Organize vantagens horizontally

### DIFF
--- a/src/pages/Vantagens.tsx
+++ b/src/pages/Vantagens.tsx
@@ -183,25 +183,25 @@ const Vantagens: React.FC = () => {
           </div>
         </section>
 
-        {/* Grid de Vantagens e Comparativo */}
+        {/* Vantagens e Comparativo */}
         <section className={`${isMobile ? 'pt-1 pb-4' : 'pt-1 pb-6'}`}>
           <div className="container mx-auto px-4">
-            <div className="grid grid-cols-1 lg:grid-cols-12 gap-4 lg:gap-6">
+            <div className="grid grid-cols-1 gap-6">
               {/* Vantagens */}
-              <div className="lg:col-span-5">
-                <div className={`grid grid-cols-2 sm:grid-cols-2 ${isMobile ? 'gap-3' : 'gap-4'}`}>
+              <div>
+                <div className={`grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 ${isMobile ? 'gap-3' : 'gap-4'}`}>
                   {vantagens.map((vantagem, index) => {
                     const Icon = vantagem.icon;
                     return (
-                      <div key={index} className={`bg-white ${isMobile ? 'p-3' : 'p-4'} rounded-lg shadow-sm hover:shadow-md transition-shadow`}>
-                        <div className={`flex items-center ${isMobile ? 'mb-2' : 'mb-3'}`}>
+                      <div key={index} className={`bg-white p-3 rounded-lg shadow-sm hover:shadow-md transition-shadow`}>
+                        <div className="flex items-center mb-2">
                           <div className={`bg-libra-blue/10 ${isMobile ? 'p-1.5' : 'p-2'} rounded-lg`}>
                             <Icon className={`${isMobile ? 'w-4 h-4' : 'w-5 h-5'} text-libra-blue`} />
                           </div>
                           <h3 className={`${isMobile ? 'text-sm' : 'text-base'} font-bold text-libra-navy ml-2`}>{vantagem.title}</h3>
                         </div>
-                        <p className={`${isMobile ? 'text-xs' : 'text-sm'} text-gray-600 ${isMobile ? 'mb-2' : 'mb-3'}`}>{vantagem.description}</p>
-                        <div className={`bg-libra-light rounded-lg ${isMobile ? 'p-2' : 'p-2'}`}>
+                        <p className={`${isMobile ? 'text-xs' : 'text-sm'} text-gray-600 mb-2`}>{vantagem.description}</p>
+                        <div className="bg-libra-light rounded-lg p-2">
                           <p className={`text-libra-navy font-medium ${isMobile ? 'text-xs' : 'text-sm'}`}>{vantagem.benefit}</p>
                         </div>
                       </div>
@@ -212,7 +212,7 @@ const Vantagens: React.FC = () => {
 
               {/* Comparativo de Taxas - apenas desktop */}
               {!isMobile && (
-                <div className="lg:col-span-7">
+                <div>
                   <div id="comparison-table-desktop" className="bg-white rounded-lg shadow-lg p-6">
                     <h2 className="text-xl font-bold text-libra-navy mb-2">Comparativo de Taxas de Juros</h2>
                     <p className="text-sm text-gray-500 mb-4">Fonte: Dados abertos do BACEN - Janeiro 2025</p>
@@ -307,9 +307,9 @@ const Vantagens: React.FC = () => {
 
             <div className={`grid ${isMobile ? 'grid-cols-2 gap-4' : 'grid-cols-2 lg:grid-cols-4 gap-6'}`}>
               {/* Passo 1 */}
-              <div className="relative">
-                <div className={`bg-white rounded-xl ${isMobile ? 'p-4' : 'p-6'} shadow-sm hover:shadow-md transition-shadow border border-gray-100`}>
-                  <div className="flex flex-col items-center text-center">
+              <div className="relative h-full">
+                <div className={`bg-white rounded-xl ${isMobile ? 'p-4' : 'p-6'} shadow-sm hover:shadow-md transition-shadow border border-gray-100 h-full flex flex-col`}>
+                  <div className="flex flex-col items-center text-center flex-grow">
                     <div className={`${isMobile ? 'w-12 h-12' : 'w-16 h-16'} bg-libra-blue/10 rounded-full flex items-center justify-center ${isMobile ? 'mb-2' : 'mb-4'}`}>
                       <FileText className={`${isMobile ? 'w-6 h-6' : 'w-8 h-8'} text-libra-blue`} />
                     </div>
@@ -334,9 +334,9 @@ const Vantagens: React.FC = () => {
               </div>
 
               {/* Passo 2 */}
-              <div className="relative">
-                <div className={`bg-white rounded-xl ${isMobile ? 'p-4' : 'p-6'} shadow-sm hover:shadow-md transition-shadow border border-gray-100`}>
-                  <div className="flex flex-col items-center text-center">
+              <div className="relative h-full">
+                <div className={`bg-white rounded-xl ${isMobile ? 'p-4' : 'p-6'} shadow-sm hover:shadow-md transition-shadow border border-gray-100 h-full flex flex-col`}>
+                  <div className="flex flex-col items-center text-center flex-grow">
                     <div className={`${isMobile ? 'w-12 h-12' : 'w-16 h-16'} bg-libra-blue/10 rounded-full flex items-center justify-center ${isMobile ? 'mb-2' : 'mb-4'}`}>
                       <MessageCircle className={`${isMobile ? 'w-6 h-6' : 'w-8 h-8'} text-libra-blue`} />
                     </div>
@@ -361,9 +361,9 @@ const Vantagens: React.FC = () => {
               </div>
 
               {/* Passo 3 */}
-              <div className="relative">
-                <div className={`bg-white rounded-xl ${isMobile ? 'p-4' : 'p-6'} shadow-sm hover:shadow-md transition-shadow border border-gray-100`}>
-                  <div className="flex flex-col items-center text-center">
+              <div className="relative h-full">
+                <div className={`bg-white rounded-xl ${isMobile ? 'p-4' : 'p-6'} shadow-sm hover:shadow-md transition-shadow border border-gray-100 h-full flex flex-col`}>
+                  <div className="flex flex-col items-center text-center flex-grow">
                     <div className={`${isMobile ? 'w-12 h-12' : 'w-16 h-16'} bg-libra-blue/10 rounded-full flex items-center justify-center ${isMobile ? 'mb-2' : 'mb-4'}`}>
                       <CheckCircle className={`${isMobile ? 'w-6 h-6' : 'w-8 h-8'} text-libra-blue`} />
                     </div>
@@ -388,9 +388,9 @@ const Vantagens: React.FC = () => {
               </div>
 
               {/* Passo 4 */}
-              <div className="relative">
-                <div className={`bg-white rounded-xl ${isMobile ? 'p-4' : 'p-6'} shadow-sm hover:shadow-md transition-shadow border border-gray-100`}>
-                  <div className="flex flex-col items-center text-center">
+              <div className="relative h-full">
+                <div className={`bg-white rounded-xl ${isMobile ? 'p-4' : 'p-6'} shadow-sm hover:shadow-md transition-shadow border border-gray-100 h-full flex flex-col`}>
+                  <div className="flex flex-col items-center text-center flex-grow">
                     <div className={`${isMobile ? 'w-12 h-12' : 'w-16 h-16'} bg-libra-blue/10 rounded-full flex items-center justify-center ${isMobile ? 'mb-2' : 'mb-4'}`}>
                       <CreditCard className={`${isMobile ? 'w-6 h-6' : 'w-8 h-8'} text-libra-blue`} />
                     </div>


### PR DESCRIPTION
## Summary
- show all advantage cards in one row on large screens
- reduce spacing so cards take less vertical space

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68659fb012408320b66f7d36a7ba40e5