### PR TITLE
Centralize desktop menu links

### DIFF
--- a/src/components/DesktopHeader.tsx
+++ b/src/components/DesktopHeader.tsx
@@ -86,12 +86,12 @@ const DesktopHeader: React.FC<DesktopHeaderProps> = ({ onPortalClientes, onSimul
             </div>
 
             {/* Navegação */}
-            <nav className="flex-1 flex items-center justify-center space-x-6 xl:space-x-10">
+            <nav className="flex-1 flex items-center justify-center space-x-6 xl:space-x-10 h-full">
               {navigationItems.map((item) => (
                 <Link
                   key={item.path}
                   to={item.path}
-                  className={`relative text-[0.81rem] lg:text-[0.9125rem] xl:text-[1.0125rem] font-medium transition-all duration-200 hover:text-libra-blue ${
+                  className={`relative flex items-center h-full text-[0.81rem] lg:text-[0.9125rem] xl:text-[1.0125rem] font-medium transition-all duration-200 hover:text-libra-blue ${
                     location.pathname === item.path
                       ? 'text-libra-blue after:absolute after:bottom-[-10px] after:left-0 after:w-full after:h-0.5 after:bg-libra-blue'
                       : 'text-libra-navy hover:text-libra-blue'


### PR DESCRIPTION
## Summary
- center navigation links vertically in DesktopHeader

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686678591ee4832098f8bd1b2527c4bc