### PR TITLE
Fix desktop header scrolling

### DIFF
--- a/src/components/DesktopHeader.tsx
+++ b/src/components/DesktopHeader.tsx
@@ -49,7 +49,10 @@ const DesktopHeader: React.FC<DesktopHeaderProps> = ({ onPortalClientes, onSimul
 
 
   return (
-    <>
+    <header
+      className="fixed top-0 left-0 right-0 z-40 bg-white shadow-sm"
+      role="banner"
+    >
       {/* Faixa superior informativa */}
       {showBanner && (
         <div className="w-full bg-libra-navy">
@@ -71,11 +74,6 @@ const DesktopHeader: React.FC<DesktopHeaderProps> = ({ onPortalClientes, onSimul
         </div>
       )}
 
-      {/* Header de navegação que permanece no topo após o scroll */}
-      <header
-        className="sticky top-0 left-0 right-0 z-40 bg-white shadow-sm"
-        role="banner"
-      >
         {/* Faixa principal */}
         <div className="border-b border-gray-100">
         <div className="container mx-auto px-4">
@@ -137,7 +135,6 @@ const DesktopHeader: React.FC<DesktopHeaderProps> = ({ onPortalClientes, onSimul
         </div>
       </div>
       </header>
-    </>
   );
 };
 

--- a/src/components/MobileLayout.tsx
+++ b/src/components/MobileLayout.tsx
@@ -36,7 +36,7 @@ const MobileLayout: React.FC<MobileLayoutProps> = ({
       <main
         id="main-content"
         data-has-header={showHeader ? "true" : "false"}
-        className={`flex-1 ${showHeader && isMobile ? 'pt-16' : ''}`}
+        className={`flex-1 ${showHeader ? 'pt-header' : ''}`}
         role="main"
         aria-label="Conteúdo principal"
       >


### PR DESCRIPTION
## Summary
- keep DesktopHeader fixed at the top
- ensure pages reserve space for the fixed header

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68669ef0ee008320960256dfdef9203c