### PR TITLE
Fix sticky desktop header

### DIFF
--- a/src/components/DesktopHeader.tsx
+++ b/src/components/DesktopHeader.tsx
@@ -49,10 +49,11 @@ const DesktopHeader: React.FC<DesktopHeaderProps> = ({ onPortalClientes, onSimul
 
 
   return (
-    <header
-      className="fixed top-0 left-0 right-0 z-40 bg-white shadow-sm"
-      role="banner"
-    >
+      <header
+        data-desktop="true"
+        className="fixed top-0 left-0 right-0 z-40 bg-white shadow-sm"
+        role="banner"
+      >
       {/* Faixa superior informativa */}
       {showBanner && (
         <div className="w-full bg-libra-navy">

--- a/src/index.css
+++ b/src/index.css
@@ -91,7 +91,18 @@
       }
     }
   }
-  
+
+  /* Desktop header fix */
+  @media (min-width: 768px) {
+    header[data-desktop="true"] {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: 50;
+    }
+  }
+
   /* Touch-Friendly Components */
   .touch-target {
     @apply min-h-[48px] min-w-[48px] flex items-center justify-center;


### PR DESCRIPTION
## Summary
- keep DesktopHeader fixed to top of the viewport
- add CSS rule for desktop header

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6866a0f35fd083209121715f360e6737