### PR TITLE
Fix desktop scale causing horizontal scroll

### DIFF
--- a/src/components/MobileLayout.tsx
+++ b/src/components/MobileLayout.tsx
@@ -32,7 +32,7 @@ const MobileLayout: React.FC<MobileLayoutProps> = ({
       {/* Header - Simplificado em mobile */}
       {showHeader && <Header />}
 
-      <div className={`flex flex-col flex-1 ${isDesktop ? 'desktop-scale' : ''}`}> 
+      <div className="flex flex-col flex-1">
         {/* Main Content */}
         <main
           id="main-content"

--- a/src/index.css
+++ b/src/index.css
@@ -274,7 +274,7 @@
   }
 
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground overflow-x-hidden;
     font-feature-settings: "rlig" 1, "calt" 1;
   }
   
@@ -565,11 +565,4 @@
     overflow: hidden;
   }
 
-}
-@media (min-width: 1024px) {
-  .desktop-scale {
-    transform: scale(0.85);
-    transform-origin: top center;
-    width: calc(100% / 0.85);
-  }
 }


### PR DESCRIPTION
## Summary
- remove leftover desktop scaling utility
- ensure main layout doesn't apply scale
- prevent horizontal scroll with hidden overflow

## Testing
- `npm run lint` *(fails: '@typescript-eslint/no-explicit-any' errors)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6866a61f6e30832098524d7c59b1d5e9