### PR TITLE
Fix blog card image cropping

### DIFF
--- a/src/components/BlogSection.tsx
+++ b/src/components/BlogSection.tsx
@@ -93,7 +93,7 @@ const BlogSection: React.FC = () => {
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 max-w-6xl mx-auto">
             {[...Array(3)].map((_, i) => (
               <Card key={i} className="animate-pulse">
-                <div className="w-full h-48 bg-gray-200 rounded-t-lg"></div>
+                <div className="w-full aspect-square bg-gray-200 rounded-t-lg"></div>
                 <CardHeader className="pb-3">
                   <div className="h-4 bg-gray-200 rounded w-1/3 mb-2"></div>
                   <div className="h-6 bg-gray-200 rounded w-full"></div>
@@ -116,11 +116,11 @@ const BlogSection: React.FC = () => {
               >
                 <Card className="hover:shadow-lg transition-all duration-300 group-hover:-translate-y-1 overflow-hidden h-full">
                   {/* Imagem do post */}
-                  <div className="aspect-video overflow-hidden rounded-t-lg">
+                  <div className="aspect-square overflow-hidden rounded-t-lg bg-white">
                     <img
                       src={post.imageUrl}
                       alt={post.title}
-                      className="w-full h-full object-cover object-center group-hover:scale-105 transition-transform duration-300"
+                      className="w-full h-full object-contain object-center group-hover:scale-105 transition-transform duration-300"
                       loading="lazy"
                       onError={(e) => {
                         const target = e.target as HTMLImageElement;

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -158,7 +158,7 @@ const Blog = () => {
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                 {[...Array(6)].map((_, i) => (
                   <div key={i} className="bg-white rounded-xl shadow-sm animate-pulse">
-                    <div className="aspect-[3/2] bg-gray-200 rounded-t-xl"></div>
+                    <div className="aspect-square bg-gray-200 rounded-t-xl"></div>
                     <div className="p-4">
                       <div className="h-4 bg-gray-200 rounded w-1/3 mb-2"></div>
                       <div className="h-6 bg-gray-200 rounded w-full mb-3"></div>
@@ -181,11 +181,11 @@ const Blog = () => {
                     className="block bg-white rounded-xl shadow-sm hover:shadow-md transition-shadow group"
                   >
                     <article>
-                      <div className="aspect-[3/2] overflow-hidden rounded-t-xl">
+                      <div className="aspect-square overflow-hidden rounded-t-xl bg-white">
                         <img
                           src={post.imageUrl}
                           alt={post.title}
-                          className="w-full h-full object-cover object-center group-hover:scale-105 transition-transform duration-300"
+                          className="w-full h-full object-contain object-center group-hover:scale-105 transition-transform duration-300"
                           loading="lazy"
                         onError={(e) => {
                           const target = e.target as HTMLImageElement;


### PR DESCRIPTION
## Summary
- adjust skeleton card aspect ratio to square
- show uncropped images in BlogSection cards
- update blog page card aspect ratio to square and use object-contain

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6866b335fda88320915e316acaacaae9