### PR TITLE
Fix blog preview image spacing

### DIFF
--- a/src/components/BlogSection.tsx
+++ b/src/components/BlogSection.tsx
@@ -120,7 +120,7 @@ const BlogSection: React.FC = () => {
                     <img
                       src={post.imageUrl}
                       alt={post.title}
-                      className="w-full h-full object-contain object-center group-hover:scale-105 transition-transform duration-300"
+                      className="w-full h-full object-cover object-center group-hover:scale-105 transition-transform duration-300"
                       loading="lazy"
                       onError={(e) => {
                         const target = e.target as HTMLImageElement;

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -185,7 +185,7 @@ const Blog = () => {
                         <img
                           src={post.imageUrl}
                           alt={post.title}
-                          className="w-full h-full object-contain object-center group-hover:scale-105 transition-transform duration-300"
+                          className="w-full h-full object-cover object-center group-hover:scale-105 transition-transform duration-300"
                           loading="lazy"
                         onError={(e) => {
                           const target = e.target as HTMLImageElement;


### PR DESCRIPTION
## Summary
- ensure blog preview images fill their containers

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867c560d81483209ee21c39d7b48371