### PR TITLE
Remove header gap above waves

### DIFF
--- a/src/components/DesktopHeader.tsx
+++ b/src/components/DesktopHeader.tsx
@@ -47,7 +47,7 @@ const DesktopHeader: React.FC<DesktopHeaderProps> = ({ onPortalClientes, onSimul
         const height = headerRef.current.offsetHeight;
         document.documentElement.style.setProperty(
           '--header-offset-desktop',
-          `${height + 16}px`
+          `${height}px`
         );
       }
     };

--- a/src/index.css
+++ b/src/index.css
@@ -258,8 +258,9 @@
     --header-height-mobile: 80px; /* py-2 (16px) + h-16 (64px) = 80px */
     /* Altura aproximada do header em desktop */
     --header-height-desktop: 86px;
-    --header-offset-mobile: 96px; /* altura + 16px de segurança */
-    --header-offset-desktop: 102px; /* altura + 16px de segurança */
+    /* Espaços compensados exatamente com a altura do header */
+    --header-offset-mobile: 80px;
+    --header-offset-desktop: 86px;
   }
 
 }


### PR DESCRIPTION
## Summary
- align wave separators directly with the header
- recalc header offset based on real header height

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fb37fd3548320b27a6e771ccda40d