### PR TITLE
Improve visual identity of simulation wizard

### DIFF
--- a/src/components/MobileWizard/index.tsx
+++ b/src/components/MobileWizard/index.tsx
@@ -182,9 +182,9 @@ export const MobileWizard: React.FC<MobileWizardProps> = ({
         </div>
         
         {/* Progress Bar */}
-        <div className="h-1 bg-gray-100 relative overflow-hidden">
+        <div className="wizard-progress">
           <div
-            className="absolute inset-y-0 left-0 bg-libra-blue transition-all duration-300 ease-out"
+            className="wizard-progress-bar transition-all duration-300 ease-out"
             style={{ width: `${progress}%` }}
           />
         </div>
@@ -195,12 +195,12 @@ export const MobileWizard: React.FC<MobileWizardProps> = ({
             <div
               key={index}
               className={cn(
-                "h-2 rounded-full transition-all duration-300",
+                "wizard-indicator",
                 index === currentStep
-                  ? "w-8 bg-libra-blue"
+                  ? "wizard-indicator-active"
                   : index < currentStep
-                  ? "w-2 bg-libra-blue"
-                  : "w-2 bg-gray-300"
+                  ? "wizard-indicator-complete"
+                  : ""
               )}
             />
           ))}

--- a/src/components/MobileWizard/steps.tsx
+++ b/src/components/MobileWizard/steps.tsx
@@ -14,7 +14,7 @@ export const ValueStep: React.FC<WizardStepProps> = ({ data, updateData, errors 
   ];
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 wizard-card">
       <div className="text-center mb-8">
         <h3 className="text-2xl font-bold text-libra-blue mb-2">
           Quanto você precisa?
@@ -24,19 +24,19 @@ export const ValueStep: React.FC<WizardStepProps> = ({ data, updateData, errors 
         </p>
       </div>
 
-      <div className="grid grid-cols-2 gap-3">
-        {values.map((option) => (
-          <button
-            key={option.value}
-            onClick={() => updateData({ loanAmount: option.value })}
-            className={cn(
-              "p-6 rounded-xl border-2 transition-all duration-200",
-              "hover:border-libra-blue hover:shadow-md",
-              "focus:outline-none focus:ring-2 focus:ring-libra-blue focus:ring-offset-2",
-              data.loanAmount === option.value
-                ? "border-libra-blue bg-blue-50 shadow-md"
-                : "border-gray-200 bg-white"
-            )}
+        <div className="grid grid-cols-2 gap-3">
+          {values.map((option) => (
+            <button
+              key={option.value}
+              onClick={() => updateData({ loanAmount: option.value })}
+              className={cn(
+                "p-6 rounded-xl border-2 transition-all duration-200 interactive-libra",
+                "hover:border-libra-blue",
+                "focus:outline-none focus:ring-2 focus:ring-libra-blue focus:ring-offset-2",
+                data.loanAmount === option.value
+                  ? "border-libra-blue bg-blue-50 shadow-libra-glow"
+                  : "border-gray-200 bg-white"
+              )}
           >
             <span className={cn(
               "text-lg font-semibold block",
@@ -89,7 +89,7 @@ export const TermStep: React.FC<WizardStepProps> = ({ data, updateData }) => {
   };
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 wizard-card">
       <div className="text-center mb-8">
         <h3 className="text-2xl font-bold text-libra-blue mb-2">
           Em quantos meses?
@@ -105,11 +105,11 @@ export const TermStep: React.FC<WizardStepProps> = ({ data, updateData }) => {
             key={term.value}
             onClick={() => updateData({ loanTerm: term.value })}
             className={cn(
-              "w-full p-4 rounded-xl border-2 transition-all duration-200 text-left",
-              "hover:border-libra-blue hover:shadow-md",
+              "w-full p-4 rounded-xl border-2 transition-all duration-200 text-left interactive-libra",
+              "hover:border-libra-blue",
               "focus:outline-none focus:ring-2 focus:ring-libra-blue focus:ring-offset-2",
               data.loanTerm === term.value
-                ? "border-libra-blue bg-blue-50 shadow-md"
+                ? "border-libra-blue bg-blue-50 shadow-libra-glow"
                 : "border-gray-200 bg-white"
             )}
           >
@@ -167,7 +167,7 @@ export const ContactStep: React.FC<WizardStepProps> = ({ data, updateData, error
   };
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 wizard-card">
       <div className="text-center mb-8">
         <h3 className="text-2xl font-bold text-libra-blue mb-2">
           Como podemos te contatar?
@@ -262,7 +262,7 @@ export const SummaryStep: React.FC<WizardStepProps> = ({ data }) => {
   const totalInterest = totalPayment - data.loanAmount;
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 wizard-card">
       <div className="text-center mb-8">
         <h3 className="text-2xl font-bold text-libra-blue mb-2">
           Sua simulação está pronta!

--- a/src/styles/minimal-premium.css
+++ b/src/styles/minimal-premium.css
@@ -333,3 +333,28 @@ html {
 .interactive-libra:active {
   transform: translateY(0) scale(0.98);
 }
+
+/* Wizard Premium Styles */
+.wizard-card {
+  @apply card-minimal p-4 md:p-6;
+}
+
+.wizard-progress {
+  @apply h-1 bg-gray-100 rounded-full overflow-hidden;
+}
+
+.wizard-progress-bar {
+  @apply h-full bg-gradient-to-r from-libra-navy via-libra-blue to-libra-cyan;
+}
+
+.wizard-indicator {
+  @apply h-2 rounded-full transition-all duration-300 bg-gray-300;
+}
+
+.wizard-indicator-active {
+  @apply w-8 bg-libra-cyan shadow-libra-glow;
+}
+
+.wizard-indicator-complete {
+  @apply w-2 bg-libra-blue;
+}


### PR DESCRIPTION
## Summary
- use premium card layout across wizard steps
- add interactive style to wizard option buttons
- style progress bar and step indicators with brand gradient
- add wizard styling utilities to minimal-premium.css

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_686fb804da208320af731e621b17b1c8