### PR TITLE
Adjust simulation form texts and slider style

### DIFF
--- a/src/components/SimulationForm.tsx
+++ b/src/components/SimulationForm.tsx
@@ -402,7 +402,7 @@ const SimulationForm: React.FC = () => {
               Sua simulação em um clique!
             </CardTitle>
             <p className="text-gray-600 text-xs">
-              Com apenas algumas informações você já encontrará a proposta ideal, com parcelas que cabem no seu bolso!
+              Com apenas algumas informações você já entende se as parcelas que cabem no orçamento!
             </p>
           </CardHeader>
           

--- a/src/components/form/CityAutocomplete.jsx
+++ b/src/components/form/CityAutocomplete.jsx
@@ -136,7 +136,7 @@ const CityAutocomplete = ({ value = '', onCityChange }) => {
       </div>
       <div className="flex-1 relative">
         <label className="block text-xs font-medium text-green-500 mb-1">
-          Selecione a cidade do imóvel a ser dado de garantia
+          Selecione a cidade do imóvel a ser utilizado como garantia
         </label>
         {/* Input with green border */}
         <input

--- a/src/components/form/CityField.tsx
+++ b/src/components/form/CityField.tsx
@@ -10,13 +10,13 @@ interface CityFieldProps {
 
 const CityField: React.FC<CityFieldProps> = ({ value, onChange }) => {
   return (
-    <div className="flex items-start gap-2">
+    <div className="flex items-center gap-2">
       <div className="bg-libra-light p-1.5 rounded-full mt-0.5">
         <MapPin className="w-4 h-4 text-green-500" />
       </div>
       <div className="flex-1">
         <label className="block text-xs font-medium text-libra-navy mb-1">
-          Selecione a cidade do imóvel a ser dado de garantia
+          Selecione a cidade do imóvel a ser utilizado como garantia
         </label>
         <Select value={value} onValueChange={onChange}>
           <SelectTrigger className="text-sm">

--- a/src/components/form/GuaranteeAmountField.tsx
+++ b/src/components/form/GuaranteeAmountField.tsx
@@ -27,7 +27,7 @@ const GuaranteeAmountField: React.FC<GuaranteeAmountFieldProps> = ({
           <Input
             value={value}
             onChange={(e) => onChange(e.target.value)}
-            placeholder="R$ 600.000"
+            placeholder="Mínimo 2x o valor do empréstimo"
             className="text-sm"
             inputMode="numeric"
           />
@@ -37,9 +37,6 @@ const GuaranteeAmountField: React.FC<GuaranteeAmountFieldProps> = ({
             O valor da garantia deve ser pelo menos 2x o valor do empréstimo
           </p>
         )}
-        <p className="text-xs text-gray-500 mt-1">
-          Digite o valor completo • Mínimo 2x o valor do empréstimo
-        </p>
       </div>
     </div>
   );

--- a/src/components/form/LoanAmountField.tsx
+++ b/src/components/form/LoanAmountField.tsx
@@ -22,14 +22,11 @@ const LoanAmountField: React.FC<LoanAmountFieldProps> = ({ value, onChange }) =>
           <Input
             value={value}
             onChange={(e) => onChange(e.target.value)}
-            placeholder="R$ 300.000"
+            placeholder="entre 75 mil e 5 milhões"
             className="text-sm"
             inputMode="numeric"
           />
         </div>
-        <p className="text-xs text-gray-500 mt-1">
-          Digite o valor completo • Entre R$ 100.000 e R$ 5.000.000
-        </p>
       </div>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -309,7 +309,7 @@
 
   /* Estilos para o slider customizado */
   .slider {
-    background: linear-gradient(to right, #40E0D0 0%, #40E0D0 var(--value, 0%), #e5e7eb var(--value, 0%), #e5e7eb 100%);
+    background: linear-gradient(to right, #22c55e 0%, #22c55e var(--value, 0%), #e5e7eb var(--value, 0%), #e5e7eb 100%);
   }
 
   .slider::-webkit-slider-thumb {
@@ -317,7 +317,7 @@
     width: 20px;
     height: 20px;
     border-radius: 50%;
-    background: #40E0D0;
+    background: #22c55e;
     cursor: pointer;
     border: 2px solid white;
     box-shadow: 0 2px 4px rgba(0,0,0,0.1);
@@ -327,7 +327,7 @@
     width: 20px;
     height: 20px;
     border-radius: 50%;
-    background: #40E0D0;
+    background: #22c55e;
     cursor: pointer;
     border: 2px solid white;
     box-shadow: 0 2px 4px rgba(0,0,0,0.1);


### PR DESCRIPTION
## Summary
- tweak intro message on SimulationForm
- center city select icon and adjust labels
- update placeholders for loan and guarantee fields
- remove hints below amount fields
- recolor installment slider to match the site's green tone

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686fba5e638c8320b96b880c6eae7bfc