### PR TITLE
Add slim wave band

### DIFF
--- a/src/components/SlimWaveBand.tsx
+++ b/src/components/SlimWaveBand.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+import WaveSeparator from '@/components/ui/WaveSeparator';
+
+interface SlimWaveBandProps {
+  className?: string;
+}
+
+const SlimWaveBand: React.FC<SlimWaveBandProps> = ({ className }) => (
+  <div className={cn('relative w-full overflow-hidden', className)}>
+    <WaveSeparator variant="hero" height="sm" inverted className="relative z-10" />
+    <div className="h-6 md:h-8 bg-[#0044cc]" />
+    <WaveSeparator variant="hero" height="sm" className="relative z-10 -mt-1" />
+  </div>
+);
+
+export default SlimWaveBand;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -9,6 +9,7 @@ import { useIsMobile } from '@/hooks/use-mobile';
 import Hero from '@/components/Hero';
 import TrustBarMinimal from '@/components/TrustBarMinimal';
 import WaveSeparator from '@/components/ui/WaveSeparator';
+import SlimWaveBand from '@/components/SlimWaveBand';
 
 // Lazy loading dos componentes pesados
 const Benefits = lazy(() => import('@/components/Benefits'));
@@ -58,7 +59,10 @@ const Index: React.FC = () => {
       <Suspense fallback={<SectionLoader />}>
         <Benefits />
       </Suspense>
-      
+
+      {/* Faixa de ondas dupla com sobreposição de azuis */}
+      <SlimWaveBand />
+
       <Suspense fallback={<SectionLoader />}>
         <Testimonials />
       </Suspense>


### PR DESCRIPTION
## Summary
- add `SlimWaveBand` component with small wave separators
- insert the slim band between Benefits and Testimonials sections

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_686fbf8b5dd08320a2caf45bd83c00b2