### PR TITLE
Add slim wave band

### DIFF
--- a/src/components/SlimWaveBand.tsx
+++ b/src/components/SlimWaveBand.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+import WaveSeparator from '@/components/ui/WaveSeparator';
+
+interface SlimWaveBandProps {
+  className?: string;
+}
+
+const SlimWaveBand: React.FC<SlimWaveBandProps> = ({ className }) => (
+  <div
+    className={cn(
+      'hidden md:block relative w-full h-6 md:h-8 bg-[#003399] overflow-hidden',
+      className
+    )}
+  >
+    <WaveSeparator
+      variant="hero"
+      height="sm"
+      inverted
+      className="absolute inset-0 bg-transparent"
+    />
+    <WaveSeparator
+      variant="hero"
+      height="sm"
+      className="absolute inset-0 bg-transparent"
+    />
+  </div>
+);
+
+export default SlimWaveBand;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -9,6 +9,7 @@ import { useIsMobile } from '@/hooks/use-mobile';
 import Hero from '@/components/Hero';
 import TrustBarMinimal from '@/components/TrustBarMinimal';
 import WaveSeparator from '@/components/ui/WaveSeparator';
+import SlimWaveBand from '@/components/SlimWaveBand';
 
 // Lazy loading dos componentes pesados
 const Benefits = lazy(() => import('@/components/Benefits'));
@@ -58,7 +59,10 @@ const Index: React.FC = () => {
       <Suspense fallback={<SectionLoader />}>
         <Benefits />
       </Suspense>
-      
+
+      {/* Faixa de ondas dupla com sobreposição de azuis - apenas desktop */}
+      {!isMobile && <SlimWaveBand />}
+
       <Suspense fallback={<SectionLoader />}>
         <Testimonials />
       </Suspense>


### PR DESCRIPTION
## Summary
- add `SlimWaveBand` component with two overlaid wave separators
- insert the slim band between Benefits and Testimonials sections
- hide slim wave band on mobile using `useIsMobile`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_686fbf8b5dd08320a2caf45bd83c00b2