### PR TITLE
Replace wave band with static logo band

### DIFF
--- a/src/components/LogoBand.tsx
+++ b/src/components/LogoBand.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import ImageOptimizer from '@/components/ImageOptimizer';
+
+const LogoBand: React.FC = () => {
+  return (
+    <div className="w-full bg-[#003399] flex justify-center py-8">
+      <div className="h-16 flex items-center">
+        <ImageOptimizer
+          src="/images/logos/libra-logo.png"
+          alt="Libra Crédito"
+          className="h-16 w-auto"
+          aspectRatio={1}
+          priority={false}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default LogoBand;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -9,7 +9,7 @@ import { useIsMobile } from '@/hooks/use-mobile';
 import Hero from '@/components/Hero';
 import TrustBarMinimal from '@/components/TrustBarMinimal';
 import WaveSeparator from '@/components/ui/WaveSeparator';
-import SlimWaveBand from '@/components/SlimWaveBand';
+import LogoBand from '@/components/LogoBand';
 
 // Lazy loading dos componentes pesados
 const Benefits = lazy(() => import('@/components/Benefits'));
@@ -60,8 +60,8 @@ const Index: React.FC = () => {
         <Benefits />
       </Suspense>
 
-      {/* Faixa de ondas dupla com sobreposição de azuis */}
-      <SlimWaveBand />
+      {/* Faixa azul com logo - apenas para desktop */}
+      {!isMobile && <LogoBand />}
 
       <Suspense fallback={<SectionLoader />}>
         <Testimonials />


### PR DESCRIPTION
## Summary
- add `LogoBand` component for the blue band with logo
- show the band only on desktop instead of wave-based `SlimWaveBand`

## Testing
- `npm run lint` *(fails: ESLint config requires packages)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_686fc71acb148320a851204278399853