### PR TITLE
Replace wave band with static logo band

### DIFF
--- a/src/components/LogoBand.tsx
+++ b/src/components/LogoBand.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import ImageOptimizer from '@/components/ImageOptimizer';
+
+const LogoBand: React.FC = () => {
+  return (
+    <div className="w-full bg-libra-navy py-1">
+      <div className="container mx-auto px-4 flex items-center justify-center gap-6">
+        <div className="h-24 flex items-center">
+          <ImageOptimizer
+            src="/images/logos/libra-logo.png"
+            alt="Libra Crédito"
+            className="h-full w-auto"
+            aspectRatio={1}
+            priority={false}
+          />
+        </div>
+        <span className="text-white text-xl font-semibold whitespace-nowrap">
+          Crédito justo, equilibrado e consciente!
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default LogoBand;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -9,7 +9,7 @@ import { useIsMobile } from '@/hooks/use-mobile';
 import Hero from '@/components/Hero';
 import TrustBarMinimal from '@/components/TrustBarMinimal';
 import WaveSeparator from '@/components/ui/WaveSeparator';
-import SlimWaveBand from '@/components/SlimWaveBand';
+import LogoBand from '@/components/LogoBand';
 
 // Lazy loading dos componentes pesados
 const Benefits = lazy(() => import('@/components/Benefits'));
@@ -60,8 +60,8 @@ const Index: React.FC = () => {
         <Benefits />
       </Suspense>
 
-      {/* Faixa de ondas dupla com sobreposição de azuis */}
-      <SlimWaveBand />
+      {/* Faixa azul com logo - apenas para desktop */}
+      {!isMobile && <LogoBand />}
 
       <Suspense fallback={<SectionLoader />}>
         <Testimonials />


### PR DESCRIPTION
## Summary
- add `LogoBand` component for the blue band with logo
- show the band only on desktop instead of wave-based `SlimWaveBand`
- style logo to take almost the entire band height and show the slogan on its right

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_686fc71acb148320a851204278399853