### PR TITLE
Ajusta faixa superior desktop 20% maior

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,8 @@
         --libra-blue: #003399;
         --libra-navy: #001166;
         --libra-gold: #D4AF37;
-        --header-height: 80px;
+        /* Increased header height by 20% for desktop layout */
+        --header-height: 96px;
       }
       
       html, body { height: 100%; }

--- a/src/components/DesktopHeader.tsx
+++ b/src/components/DesktopHeader.tsx
@@ -95,11 +95,12 @@ const DesktopHeader: React.FC<DesktopHeaderProps> = ({ onPortalClientes, onSimul
         {/* Faixa principal */}
         <div className="border-b border-gray-100">
         <div className="container mx-auto px-4">
-          <div className="flex items-center justify-between h-[52px] lg:h-[68px]">
+          {/* Height increased 20% for desktop */}
+          <div className="flex items-center justify-between h-[62px] lg:h-[82px]">
             {/* Logo e slogan */}
             <div className="flex items-center gap-6">
               <Link to="/" className="flex items-center">
-                <div className="h-[52px] lg:h-[68px] overflow-hidden flex items-center">
+                <div className="h-[62px] lg:h-[82px] overflow-hidden flex items-center">
                   <ImageOptimizer
                     src="/images/logos/libra-logo.png"
                     alt="Libra Crédito - Home Equity com garantia de imóvel"

--- a/src/index.css
+++ b/src/index.css
@@ -257,10 +257,11 @@
     /* Header Heights - Calculadas com base nos componentes */
     --header-height-mobile: 80px; /* py-2 (16px) + h-16 (64px) = 80px */
     /* Altura aproximada do header em desktop */
-    --header-height-desktop: 86px;
+    /* Increased by 20% for larger desktop header */
+    --header-height-desktop: 103px;
     /* Espaços compensados exatamente com a altura do header */
     --header-offset-mobile: 80px;
-    --header-offset-desktop: 86px;
+    --header-offset-desktop: 103px;
   }
 
 }

--- a/src/styles/critical.css
+++ b/src/styles/critical.css
@@ -16,7 +16,8 @@ body {
   --libra-blue: #003399;
   --libra-navy: #001166;
   --libra-gold: #D4AF37;
-  --header-height: 80px;
+  /* Increased header height by 20% for desktop */
+  --header-height: 96px;
 }
 
 /* Layout básico */


### PR DESCRIPTION
## Summary
- increase `--header-height` for first render
- bump header sizing variables for desktop
- enlarge main desktop header heights

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_686fcab898348320aeb01150f02beec8