### PR TITLE
Fix mobile result display

### DIFF
--- a/src/components/SimulationForm.tsx
+++ b/src/components/SimulationForm.tsx
@@ -482,8 +482,8 @@ const SimulationForm: React.FC = () => {
         </Card>
 
         {/* Resultado ou Complemento */}
-        {showSideComplement && (
-          <div data-result-section="true">
+        {(resultado || (isLtvMessage && apiMessage)) && (
+          <div data-result-section="true" className={showSideComplement ? '' : 'mt-4'}>
             {resultado ? (
               <SimulationResultDisplay
                 resultado={resultado}
@@ -494,14 +494,12 @@ const SimulationForm: React.FC = () => {
                 onSwitchToPrice={handleSwitchToPrice}
               />
             ) : (
-              isLtvMessage && apiMessage && (
-                <SmartApiMessage
-                  analysis={apiMessage}
-                  valorImovel={validation.garantiaValue}
-                  onAdjustValues={handleAdjustValues}
-                  onTryAgain={handleTryAgain}
-                />
-              )
+              <SmartApiMessage
+                analysis={apiMessage as ApiMessageAnalysis}
+                valorImovel={validation.garantiaValue}
+                onAdjustValues={handleAdjustValues}
+                onTryAgain={handleTryAgain}
+              />
             )}
           </div>
         )}


### PR DESCRIPTION
## Summary
- ensure result display and smart message appear on mobile

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' and many lint errors)*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686fcb90d87883209e8984345eb2ded6