### PR TITLE
Update logo band with slogan

### DIFF
--- a/src/components/LogoBand.tsx
+++ b/src/components/LogoBand.tsx
@@ -3,15 +3,18 @@ import ImageOptimizer from '@/components/ImageOptimizer';
 
 const LogoBand: React.FC = () => {
   return (
-    <div className="w-full bg-[#003399] flex justify-center py-8">
-      <div className="h-16 flex items-center">
+    <div className="w-full bg-[#003399] flex justify-center py-4">
+      <div className="flex items-center h-20">
         <ImageOptimizer
           src="/images/logos/libra-logo.png"
           alt="Libra Crédito"
-          className="h-16 w-auto"
+          className="h-[90%] w-auto"
           aspectRatio={1}
           priority={false}
         />
+        <span className="ml-4 text-white text-lg font-semibold whitespace-nowrap">
+          Crédito justo, equilibrado e consciente!
+        </span>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- adjust `LogoBand` layout so logo fills 90% of its strip height
- place slogan text on the right side of the logo

## Testing
- `npm run lint` *(fails: 64 errors, 26 warnings)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_686fd27e38a48320bb0a5eebf9c2fa28