### PR TITLE
Improve CSS loading speed

### DIFF
--- a/index.html
+++ b/index.html
@@ -199,6 +199,14 @@
     <!-- Font Display Optimized (Async) -->
     <link rel="preload" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&display=swap" rel="stylesheet"></noscript>
+
+    <!-- Async CSS to reduce render blocking -->
+    <link rel="stylesheet" href="/src/index.css" media="print" onload="this.media='all'">
+    <link rel="stylesheet" href="/src/styles/minimal-premium.css" media="print" onload="this.media='all'">
+    <noscript>
+      <link rel="stylesheet" href="/src/index.css" />
+      <link rel="stylesheet" href="/src/styles/minimal-premium.css" />
+    </noscript>
     
     <!-- Favicon - Libra Crédito -->
     <link rel="icon" href="/favicon.png" type="image/png" />


### PR DESCRIPTION
## Summary
- defer main stylesheets in the page head to reduce render blocking

## Testing
- `npm run build`
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any, no-require-imports)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_686fdcb0bab8832094be19b19f022249