### PR TITLE
Adjust hero heading sizing

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -57,8 +57,11 @@ const Hero: React.FC = () => {
             {isMobile && <div className="h-8"></div>}
             
             <div>
-                <h1 id="hero-heading" className="text-[1.5rem] md:text-[1.8rem] lg:text-[1.8rem] xl:text-[2.25rem] 2xl:text-[2.7rem] font-bold mb-3 md:mb-3 lg:mb-3 leading-tight">
-                  Crédito Com Garantia de Imóvel
+                <h1
+                  id="hero-heading"
+                  className="text-base md:text-lg lg:text-xl xl:text-2xl 2xl:text-3xl font-bold mb-3 md:mb-3 lg:mb-3 leading-tight"
+                >
+                  <span className="whitespace-nowrap">Crédito Com Garantia de Imóvel</span>
                   <br />
                   é mais simples na Libra!
                 </h1>

--- a/src/components/HeroMinimal.tsx
+++ b/src/components/HeroMinimal.tsx
@@ -73,9 +73,9 @@ const HeroMinimal: React.FC = () => {
               <FloatingElement delay={200}>
                 <h1
                   id="hero-heading"
-                  className="text-3xl md:text-4xl lg:text-5xl font-bold leading-tight text-white"
+                  className="text-2xl md:text-3xl lg:text-4xl font-bold leading-tight text-white"
                 >
-                  Crédito Com Garantia de Imóvel
+                  <span className="whitespace-nowrap">Crédito Com Garantia de Imóvel</span>
                   <br />
                   é mais simples na Libra!
                   <br />


### PR DESCRIPTION
## Summary
- keep the hero heading text on two lines regardless of screen size
- shrink the hero heading on the minimal version

## Testing
- `npm run lint` *(fails: Unexpected any in various files)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_686fe2980bb8832093c4d2e533fdb508