### PR TITLE
Add geolocation-based city detection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ VITE_SUPABASE_ANON_KEY=your_supabase_anon_key_here
 
 # API Configuration
 VITE_API_BASE_URL=https://api.exemplo.com
+VITE_OPENCAGE_API_KEY=your_opencage_api_key_here
 
 # Ploomes CRM Integration
 VITE_PLOOMES_API_KEY=your_ploomes_api_key_here

--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ VITE_SUPABASE_ANON_KEY=your_supabase_anon_key_here
 
 # API Configuration
 VITE_API_BASE_URL=https://api.exemplo.com
-VITE_OPENCAGE_API_KEY=your_opencage_api_key_here
+VITE_OPENCAGE_API_KEY=e49a2c0ce3664a02881d66a3361ea8c2
 
 # Ploomes CRM Integration
 VITE_PLOOMES_API_KEY=your_ploomes_api_key_here

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ cp .env.example .env
 # Configure suas variáveis no arquivo .env:
 # - VITE_SUPABASE_URL e VITE_SUPABASE_ANON_KEY (obrigatório)
 # - VITE_WEBHOOK_URL (opcional - para webhook de simulações)
-# - VITE_OPENCAGE_API_KEY (necessário para geocodificação)
+# - VITE_OPENCAGE_API_KEY (necessário para geocodificação – já incluso em `.env.example` para testes)
 # - Outras conforme necessário
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ cp .env.example .env
 # Configure suas variáveis no arquivo .env:
 # - VITE_SUPABASE_URL e VITE_SUPABASE_ANON_KEY (obrigatório)
 # - VITE_WEBHOOK_URL (opcional - para webhook de simulações)
+# - VITE_OPENCAGE_API_KEY (necessário para geocodificação)
 # - Outras conforme necessário
 ```
 

--- a/src/components/SimulationForm.tsx
+++ b/src/components/SimulationForm.tsx
@@ -61,6 +61,7 @@ import SimulationResultDisplay from './SimulationResultDisplay';
 import { analyzeApiMessage, ApiMessageAnalysis } from '@/utils/apiMessageAnalyzer';
 import { analyzeLocalMessage } from '@/utils/localMessageAnalyzer';
 import { formatBRL, norm } from '@/utils/formatters';
+import { getAllCities } from '@/utils/cityLtvService';
 
 const SimulationForm: React.FC = () => {
   const { sessionId, trackSimulation } = useUserJourney();
@@ -73,6 +74,7 @@ const SimulationForm: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [resultado, setResultado] = useState<SimulationResult | null>(null);
   const [erro, setErro] = useState('');
+  const [erroTipo, setErroTipo] = useState<'error' | 'warning' | 'info'>('error');
   const [apiMessage, setApiMessage] = useState<ApiMessageAnalysis | null>(null);
   const [isRuralProperty, setIsRuralProperty] = useState(false);
 
@@ -85,6 +87,62 @@ const SimulationForm: React.FC = () => {
 
   const handleGarantiaChange = (value: string) => {
     setGarantia(formatBRL(value));
+  };
+
+  // Detectar cidade automaticamente usando geolocalização
+  const fetchCityFromLocation = () => {
+    if (!navigator.geolocation) {
+      setErro('Geolocaliza\u00e7\u00e3o n\u00e3o suportada pelo navegador.');
+      setErroTipo('warning');
+      return;
+    }
+
+    setErro('');
+    setErroTipo('info');
+
+    navigator.geolocation.getCurrentPosition(
+      async position => {
+        try {
+          const { latitude, longitude } = position.coords;
+          const key = import.meta.env.VITE_OPENCAGE_API_KEY;
+          const url = `https://api.opencagedata.com/geocode/v1/json?q=${latitude}+${longitude}&key=${key}&language=pt-BR`;
+          const resp = await fetch(url);
+          const data = await resp.json();
+          const comp = data.results?.[0]?.components;
+          const cityName = comp?.city || comp?.town || comp?.village;
+          const state = comp?.state_code;
+          if (cityName && state) {
+            const formatted = `${cityName.toUpperCase()} - ${state}`;
+            const all = getAllCities();
+            if (all.includes(formatted)) {
+              setCidade(formatted);
+              setErro('');
+            } else {
+              setCidade(formatted);
+              setErro('Cidade detectada diferente do padr\u00e3o. Confirme ou ajuste manualmente.');
+              setErroTipo('warning');
+            }
+          } else {
+            setErro('N\u00e3o foi poss\u00edvel determinar sua cidade.');
+            setErroTipo('warning');
+          }
+        } catch (err) {
+          console.error('Erro ao buscar cidade:', err);
+          setErro('Erro ao obter cidade pela localiza\u00e7\u00e3o.');
+          setErroTipo('error');
+        }
+      },
+      error => {
+        console.error('Geo erro', error);
+        if (error.code === error.PERMISSION_DENIED) {
+          setErro('Permiss\u00e3o de localiza\u00e7\u00e3o negada.');
+          setErroTipo('warning');
+        } else {
+          setErro('N\u00e3o foi poss\u00edvel acessar sua localiza\u00e7\u00e3o.');
+          setErroTipo('error');
+        }
+      }
+    );
   };
 
   // Função para rolar para o resultado no mobile
@@ -106,6 +164,7 @@ const SimulationForm: React.FC = () => {
 
     setLoading(true);
     setErro('');
+    setErroTipo('error');
     setResultado(null);
 
     try {
@@ -156,6 +215,7 @@ const SimulationForm: React.FC = () => {
           // É uma mensagem estruturada do serviço local
           setApiMessage(analysis);
           setErro(''); // Limpar erro genérico
+          setErroTipo('error');
         } else {
           // É um erro genérico
           let errorMessage = 'Erro desconhecido ao realizar simulação';
@@ -167,10 +227,12 @@ const SimulationForm: React.FC = () => {
           }
           
           setErro(errorMessage);
+          setErroTipo('error');
           setApiMessage(null);
         }
       } else {
         setErro('Erro desconhecido ao realizar simulação');
+        setErroTipo('error');
         setApiMessage(null);
       }
     } finally {
@@ -186,6 +248,7 @@ const SimulationForm: React.FC = () => {
     setCidade('');
     setResultado(null);
     setErro('');
+    setErroTipo('error');
     setApiMessage(null);
     setIsRuralProperty(false);
   };
@@ -197,6 +260,7 @@ const SimulationForm: React.FC = () => {
     setIsRuralProperty(isRural);
     setApiMessage(null);
     setErro('');
+    setErroTipo('error');
 
     // Aguardar um pouco para garantir que os estados sejam atualizados
     setTimeout(async () => {
@@ -267,6 +331,8 @@ const SimulationForm: React.FC = () => {
           if (analysis.type !== 'unknown_error') {
             setApiMessage(analysis);
             setErro('');
+            setErroTipo('error');
+            setErroTipo('error');
           } else {
             let errorMessage = 'Erro ao processar simulação automática';
             
@@ -277,10 +343,12 @@ const SimulationForm: React.FC = () => {
             }
             
             setErro(errorMessage);
+            setErroTipo('error');
             setApiMessage(null);
           }
         } else {
           setErro('Erro desconhecido na simulação automática');
+          setErroTipo('error');
           setApiMessage(null);
         }
       } finally {
@@ -293,6 +361,7 @@ const SimulationForm: React.FC = () => {
   const handleTryAgain = () => {
     setApiMessage(null);
     setErro('');
+    setErroTipo('error');
     setResultado(null);
     // Manter os valores preenchidos para facilitar nova tentativa
   };
@@ -302,6 +371,7 @@ const SimulationForm: React.FC = () => {
     setResultado(null);
     setApiMessage(null);
     setErro('');
+    setErroTipo('error');
     // Manter valores para facilitar nova simulação
   };
 
@@ -313,6 +383,7 @@ const SimulationForm: React.FC = () => {
     setAmortizacao('PRICE');
     setApiMessage(null);
     setErro('');
+    setErroTipo('error');
     setLoading(true);
 
     // Aguardar um pouco para garantir que o estado seja atualizado
@@ -363,10 +434,12 @@ const SimulationForm: React.FC = () => {
             setErro('');
           } else {
             setErro('Erro ao refazer simulação com tabela PRICE');
+            setErroTipo('error');
             setApiMessage(null);
           }
         } else {
           setErro('Erro desconhecido ao refazer simulação');
+          setErroTipo('error');
           setApiMessage(null);
         }
       } finally {
@@ -403,6 +476,16 @@ const SimulationForm: React.FC = () => {
             <form onSubmit={handleSubmit} className="space-y-2">
               
               <CityAutocomplete value={cidade} onCityChange={setCidade} />
+              <div className="flex justify-end">
+                <Button
+                  type="button"
+                  variant="secondary"
+                  className="mt-1 text-xs"
+                  onClick={fetchCityFromLocation}
+                >
+                  Detectar minha cidade
+                </Button>
+              </div>
 
               <LoanAmountField value={emprestimo} onChange={handleEmprestimoChange} />
 
@@ -457,15 +540,16 @@ const SimulationForm: React.FC = () => {
               {/* Erro genérico */}
               {erro && !apiMessage && (
                 <div className="mt-3">
-                  <ApiMessageDisplay 
+                  <ApiMessageDisplay
                     message={erro}
-                    type="error"
-                    onRetry={() => {
-                      setErro('');
-                      if (validation.formularioValido) {
-                        handleSubmit(new Event('submit') as any);
-                      }
-                    }}
+                    type={erroTipo}
+                      onRetry={() => {
+                        setErro('');
+                        setErroTipo('error');
+                        if (validation.formularioValido) {
+                          handleSubmit(new Event('submit') as any);
+                        }
+                      }}
                     showRetryButton={validation.formularioValido}
                   />
                 </div>

--- a/src/components/SimulationForm.tsx
+++ b/src/components/SimulationForm.tsx
@@ -97,6 +97,13 @@ const SimulationForm: React.FC = () => {
       return;
     }
 
+    const key = import.meta.env.VITE_OPENCAGE_API_KEY;
+    if (!key) {
+      setErro('Chave da API de geocodifica\u00e7\u00e3o n\u00e3o configurada.');
+      setErroTipo('error');
+      return;
+    }
+
     setErro('');
     setErroTipo('info');
 
@@ -107,6 +114,11 @@ const SimulationForm: React.FC = () => {
           const key = import.meta.env.VITE_OPENCAGE_API_KEY;
           const url = `https://api.opencagedata.com/geocode/v1/json?q=${latitude}+${longitude}&key=${key}&language=pt-BR`;
           const resp = await fetch(url);
+          if (!resp.ok) {
+            setErro('Falha ao consultar a API de geocodifica\u00e7\u00e3o.');
+            setErroTipo('error');
+            return;
+          }
           const data = await resp.json();
           const comp = data.results?.[0]?.components;
           const cityName = comp?.city || comp?.town || comp?.village;


### PR DESCRIPTION
## Summary
- enable geolocation in `SimulationForm`
- add "Detectar minha cidade" button
- record geocoding API key in `.env.example`
- document new environment variable in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_686fe526da588320bd12ff155d642093