### PR TITLE
Fix menu overlap and center hero on tablets

### DIFF
--- a/src/components/DesktopHeader.tsx
+++ b/src/components/DesktopHeader.tsx
@@ -109,12 +109,12 @@ const DesktopHeader: React.FC<DesktopHeaderProps> = ({ onPortalClientes, onSimul
             </div>
 
             {/* Navegação */}
-            <nav className="flex-1 flex items-center justify-center space-x-6 xl:space-x-10 h-full">
+            <nav className="flex-1 flex items-center justify-center space-x-4 md:space-x-6 xl:space-x-10 h-full">
               {navigationItems.map((item) => (
                 <Link
                   key={item.path}
                   to={item.path}
-                  className={`relative flex items-center h-full text-[1.0125rem] lg:text-[1.1406rem] xl:text-[1.2656rem] font-medium transition-all duration-200 hover:text-libra-blue ${
+                  className={`relative flex items-center h-full text-[0.95rem] md:text-[1.0125rem] lg:text-[1.1406rem] xl:text-[1.2656rem] font-medium transition-all duration-200 hover:text-libra-blue ${
                     location.pathname === item.path
                       ? 'text-libra-blue after:absolute after:bottom-[-10px] after:left-0 after:w-full after:h-0.5 after:bg-libra-blue'
                       : 'text-libra-navy hover:text-libra-blue'

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -52,7 +52,7 @@ const Hero: React.FC = () => {
       <div className="container mx-auto px-4 relative z-10 flex-grow flex flex-col justify-center">
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 lg:gap-8 items-center">
           {/* Lado Esquerdo */}
-          <div className="text-[#003399] space-y-3 md:space-y-4 lg:space-y-3 xl:space-y-5">
+          <div className="text-[#003399] space-y-3 md:space-y-4 lg:space-y-3 xl:space-y-5 md:text-center md:flex md:flex-col md:items-center">
             {/* Espaçamento extra para mobile */}
             {isMobile && <div className="h-8"></div>}
             
@@ -85,7 +85,7 @@ const Hero: React.FC = () => {
             </div>
 
             {/* Botões */}
-            <div className="flex flex-col sm:flex-row gap-3 sm:gap-3 lg:gap-3">
+            <div className="flex flex-col sm:flex-row gap-3 sm:gap-3 lg:gap-3 md:justify-center">
               <PremiumButton 
                 onClick={scrollToSimulator} 
                 variant="primary"


### PR DESCRIPTION
## Summary
- tweak desktop header navigation spacing and font size to avoid overlap on mid-sized screens
- center hero section content on tablet widths

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_686fef7ecf74832098f2c0c4a59d461e