### PR TITLE
Adjust hero heading size for two lines

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -59,7 +59,7 @@ const Hero: React.FC = () => {
             <div>
                 <h1
                   id="hero-heading"
-                  className="text-base md:text-lg lg:text-xl xl:text-2xl 2xl:text-3xl font-bold mb-3 md:mb-3 lg:mb-3 leading-tight"
+                  className="text-[clamp(1rem,5vw,3.75rem)] font-bold mb-3 leading-tight"
                 >
                   <span className="whitespace-nowrap">Crédito Com Garantia de Imóvel</span>
                   <br />

--- a/src/components/HeroMinimal.tsx
+++ b/src/components/HeroMinimal.tsx
@@ -73,7 +73,7 @@ const HeroMinimal: React.FC = () => {
               <FloatingElement delay={200}>
                 <h1
                   id="hero-heading"
-                  className="text-2xl md:text-3xl lg:text-4xl font-bold leading-tight text-white"
+                  className="text-[clamp(1rem,5vw,3.75rem)] font-bold leading-tight text-white"
                 >
                   <span className="whitespace-nowrap">Crédito Com Garantia de Imóvel</span>
                   <br />


### PR DESCRIPTION
## Summary
- make hero heading responsive using `clamp()`
- do the same for HeroMinimal

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fefa2a30c8320ab6a1f49f05cee72