### PR TITLE
Adjust hero heading font size

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -59,7 +59,7 @@ const Hero: React.FC = () => {
             <div>
                 <h1
                   id="hero-heading"
-                  className="text-[clamp(1.15rem,5.75vw,4.3125rem)] font-bold mb-3 leading-tight"
+                  className="text-[1.125rem] md:text-[1.35rem] lg:text-[1.35rem] xl:text-[1.6875rem] 2xl:text-[2.025rem] font-bold mb-3 leading-tight"
                 >
                   <span className="whitespace-nowrap">Crédito Com Garantia de Imóvel</span>
                   <br />

--- a/src/components/HeroMinimal.tsx
+++ b/src/components/HeroMinimal.tsx
@@ -73,7 +73,7 @@ const HeroMinimal: React.FC = () => {
               <FloatingElement delay={200}>
                 <h1
                   id="hero-heading"
-                  className="text-[clamp(1.15rem,5.75vw,4.3125rem)] font-bold leading-tight text-white"
+                  className="text-[1.125rem] md:text-[1.35rem] lg:text-[1.35rem] xl:text-[1.6875rem] 2xl:text-[2.025rem] font-bold leading-tight text-white"
                 >
                   <span className="whitespace-nowrap">Crédito Com Garantia de Imóvel</span>
                   <br />


### PR DESCRIPTION
## Summary
- make 'Crédito Com Garantia de Imóvel' font size match the 'Libere até 50% do valor do seu imóvel' line

## Testing
- `npm run lint` *(fails: cannot specify any types, 93 problems)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_686ffa414ff88320bc6a10f2c10a3bfe