### PR TITLE
Fix hero tagline alignment

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -71,7 +71,7 @@ const Hero: React.FC = () => {
                 </p>
                 <div className="flex items-center gap-3 justify-center">
                   <Shield className="w-5 h-5 lg:w-5 lg:h-5 text-[#003399] flex-shrink-0" aria-hidden="true" />
-                  <p className="text-xs md:text-sm lg:text-sm xl:text-base text-[#003399] leading-relaxed font-bold">
+                  <p className="text-xs md:text-sm lg:text-sm xl:text-base text-[#003399] leading-relaxed font-bold text-center">
                     Atendimento Personalizado, Segurança e Transparência!
                   </p>
                 </div>

--- a/src/components/HeroMinimal.tsx
+++ b/src/components/HeroMinimal.tsx
@@ -91,7 +91,7 @@ const HeroMinimal: React.FC = () => {
                   </p>
                   <div className="flex items-center gap-3 justify-center">
                     <Shield className="w-5 h-5 text-[#00ccff] flex-shrink-0" aria-hidden="true" />
-                    <p className="text-base md:text-lg text-white/80 leading-relaxed font-bold">
+                    <p className="text-base md:text-lg text-white/80 leading-relaxed font-bold text-center">
                       Atendimento Personalizado, Segurança e Transparência!
                     </p>
                   </div>


### PR DESCRIPTION
## Summary
- ensure tagline in hero components is centered

## Testing
- `npm run lint` *(fails: Unexpected any errors)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_687006844a38832094d7c73166179f24