### PR TITLE
Add RA Verified seal to footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { ChevronUp, Phone, Mail, Facebook, Instagram, Linkedin, Youtube, ExternalLink } from 'lucide-react';
+import RASeal from '@/components/RASeal';
 import WaveSeparator from '@/components/ui/WaveSeparator';
 import ImageOptimizer from '@/components/ImageOptimizer';
 
@@ -107,16 +108,7 @@ const Footer: React.FC = () => {
               </a>
             </div>
 
-            <div id="ra-verified-seal">
-              <script
-                type="text/javascript"
-                id="ra-embed-verified-seal"
-                src="https://s3.amazonaws.com/raichu-beta/ra-verified/bundle.js"
-                data-id="Y21PdzlSbG1iOEw4ZWVzMDpsaWJyYS1jcmVkaXRvLXNvbHVjb2VzLWZpbmFuY2VpcmFz"
-                data-target="ra-verified-seal"
-                data-model="2"
-              ></script>
-            </div>
+            <RASeal />
             
             {/* Botão Voltar ao Topo - apenas desktop */}
             <button 

--- a/src/components/RASeal.tsx
+++ b/src/components/RASeal.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+
+const RASeal = () => {
+  useEffect(() => {
+    const container = document.getElementById('ra-verified-seal');
+    if (!container) return;
+    const script = document.createElement('script');
+    script.type = 'text/javascript';
+    script.id = 'ra-embed-verified-seal';
+    script.src = 'https://s3.amazonaws.com/raichu-beta/ra-verified/bundle.js';
+    script.dataset.id = 'Y21PdzlSbG1iOEw4ZWVzMDpsaWJyYS1jcmVkaXRvLXNvbHVjb2VzLWZpbmFuY2VpcmFz';
+    script.dataset.target = 'ra-verified-seal';
+    script.dataset.model = '2';
+    container.appendChild(script);
+  }, []);
+
+  return <div id="ra-verified-seal" />;
+};
+
+export default RASeal;


### PR DESCRIPTION
## Summary
- create `RASeal` component to dynamically load ReclameAQUI widget
- render the seal under social media icons in `Footer`

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870153bd33c8320b1f4b21225f0b691