### PR TITLE
Add RA Verified seal to footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { ChevronUp, Phone, Mail, Facebook, Instagram, Linkedin, Youtube, ExternalLink } from 'lucide-react';
+import RASeal from '@/components/RASeal';
 import WaveSeparator from '@/components/ui/WaveSeparator';
 import ImageOptimizer from '@/components/ImageOptimizer';
 
@@ -107,26 +108,20 @@ const Footer: React.FC = () => {
               </a>
             </div>
 
-            <div id="ra-verified-seal">
-              <script
-                type="text/javascript"
-                id="ra-embed-verified-seal"
-                src="https://s3.amazonaws.com/raichu-beta/ra-verified/bundle.js"
-                data-id="Y21PdzlSbG1iOEw4ZWVzMDpsaWJyYS1jcmVkaXRvLXNvbHVjb2VzLWZpbmFuY2VpcmFz"
-                data-target="ra-verified-seal"
-                data-model="2"
-              ></script>
-            </div>
-            
             {/* Botão Voltar ao Topo - apenas desktop */}
-            <button 
-              onClick={scrollToTop} 
+            <button
+              onClick={scrollToTop}
               className="hidden md:flex items-center gap-1 md:gap-2 ml-auto text-white/80 hover:text-white transition-colors text-xs md:text-sm"
               aria-label="Voltar ao topo"
             >
               <ChevronUp className="w-3 h-3 md:w-4 md:h-4" />
               <span className="hidden md:inline">Voltar ao topo</span>
             </button>
+          </div>
+
+          {/* Selo ReclameAQUI - posicionamento responsivo */}
+          <div className="col-span-3 md:col-span-1 md:col-start-3 flex justify-center md:justify-end">
+            <RASeal className="mx-auto md:ml-auto" />
           </div>
         </div>
 

--- a/src/components/RASeal.tsx
+++ b/src/components/RASeal.tsx
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+
+interface RASealProps {
+  className?: string;
+}
+
+const RASeal: React.FC<RASealProps> = ({ className }) => {
+  useEffect(() => {
+    const container = document.getElementById('ra-verified-seal');
+    if (!container) return;
+    if (!document.getElementById('ra-embed-verified-seal')) {
+      const script = document.createElement('script');
+      script.type = 'text/javascript';
+      script.id = 'ra-embed-verified-seal';
+      script.src =
+        'https://s3.amazonaws.com/raichu-beta/ra-verified/bundle.js';
+      script.dataset.id =
+        'Y21PdzlSbG1iOEw4ZWVzMDpsaWJyYS1jcmVkaXRvLXNvbHVjb2VzLWZpbmFuY2VpcmFz';
+      script.dataset.target = 'ra-verified-seal';
+      script.dataset.model = '2';
+      container.appendChild(script);
+    }
+  }, []);
+
+  return <div id="ra-verified-seal" className={className} />;
+};
+
+export default RASeal;


### PR DESCRIPTION
## Summary
- create `RASeal` component to dynamically load ReclameAQUI widget
- render the seal responsively in the footer: centered under the logo on mobile and right-aligned on desktop

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: 67 errors, 26 warnings)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6870153bd33c8320b1f4b21225f0b691