### PR TITLE
Fix hero heading line break

### DIFF
--- a/src/components/HeroPremium.tsx
+++ b/src/components/HeroPremium.tsx
@@ -59,10 +59,10 @@ const HeroPremium: React.FC = () => {
             <div>
               <h1
                 id="hero-heading"
-                className="text-3xl md:text-4xl lg:text-5xl font-extrabold mb-4 leading-tight"
+                className="text-xl md:text-3xl lg:text-4xl font-extrabold mb-4 leading-tight"
               >
-                Crédito com Garantia de Imóvel
-                <span className="text-green-600"> é mais simples na Libra!</span>
+                <span className="block whitespace-nowrap">Crédito com Garantia de Imóvel</span>
+                <span className="block text-green-600">é mais simples na Libra!</span>
               </h1>
               <p className="text-lg md:text-xl lg:text-2xl text-[#003399] font-semibold">
                 Crédito inteligente para quem construiu patrimônio


### PR DESCRIPTION
## Summary
- shrink hero heading font size so it doesn't overlap the video
- reduce mobile font size to avoid text cutting

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_687684f416a08320a476159f4f1a8a3f