### PR TITLE
Adjust hero button size on mobile

### DIFF
--- a/src/components/HeroPremium.tsx
+++ b/src/components/HeroPremium.tsx
@@ -82,7 +82,7 @@ const HeroPremium: React.FC = () => {
             </div>
 
             {/* Botões */}
-            <div className="flex flex-col sm:flex-row gap-4 w-full max-w-sm mx-auto pt-4">
+            <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 w-full max-w-sm mx-auto pt-3 sm:pt-4">
               <HeroButton
                 onClick={scrollToSimulator}
                 variant="primary"

--- a/src/components/ui/HeroButton.tsx
+++ b/src/components/ui/HeroButton.tsx
@@ -8,7 +8,7 @@ const HeroButton = React.forwardRef<
   }
 >(({ className, variant = 'primary', ...props }, ref) => {
   const baseClasses =
-    'w-full rounded-lg px-8 py-4 text-base font-bold transition-all duration-300 ease-in-out transform focus:outline-none focus:ring-4 focus:ring-opacity-50';
+    'w-full rounded-lg px-6 py-3 text-sm sm:px-8 sm:py-4 sm:text-base font-bold transition-all duration-300 ease-in-out transform focus:outline-none focus:ring-4 focus:ring-opacity-50';
 
   const variantClasses = {
     primary:


### PR DESCRIPTION
## Summary
- tweak HeroButton base classes for smaller mobile size
- reduce gap and padding for hero CTA container

## Testing
- `npm run lint` *(fails: Unexpected any errors)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68768ccf0d94832088e4d91c5ca3f534