### PR TITLE
Reduce forced reflows

### DIFF
--- a/src/components/DesktopHeader.tsx
+++ b/src/components/DesktopHeader.tsx
@@ -40,16 +40,26 @@ const DesktopHeader: React.FC<DesktopHeaderProps> = ({ onPortalClientes, onSimul
   const [showBanner, setShowBanner] = useState(true);
   const headerRef = useRef<HTMLElement | null>(null);
 
-  // Atualiza o offset do header sempre que o banner é exibido ou ocultado
+  // Atualiza o offset do header reagindo a mudanças de tamanho
   useLayoutEffect(() => {
-    if (headerRef.current) {
-      const { offsetHeight } = headerRef.current;
+    const header = headerRef.current;
+    if (!header) return;
+
+    const updateOffset = () => {
+      const { offsetHeight } = header;
       document.documentElement.style.setProperty(
         '--header-offset-desktop',
         `${offsetHeight}px`
       );
-    }
-  }, [showBanner]);
+    };
+
+    updateOffset();
+
+    const resizeObs = new ResizeObserver(updateOffset);
+    resizeObs.observe(header);
+
+    return () => resizeObs.disconnect();
+  }, []);
 
   const navigationItems = [
     { name: 'Home', path: '/' },

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -18,29 +18,39 @@ const Hero: React.FC = () => {
     navigate('/vantagens');
   };
 
-  const scrollToBenefits = () => {
+  const targetRef = React.useRef<number>(0);
+
+  const computeTarget = React.useCallback(() => {
     const card = document.getElementById('capital-giro-card');
     const trustbar = document.getElementById('trustbar');
-    if (card) {
-      const headerOffset = window.innerWidth < 768 ? 96 : 108;
-      const trustbarRect = trustbar?.getBoundingClientRect();
-      const cardRect = card.getBoundingClientRect();
-      const trustbarHeight = trustbarRect ? trustbarRect.height : 0;
-      const cardHeight = cardRect.height;
-      const centerOffset = (window.innerHeight - cardHeight) / 2;
-      const baseTarget =
-        cardRect.top +
-        window.pageYOffset -
-        headerOffset -
-        trustbarHeight -
-        centerOffset;
+    if (!card) return;
 
-      const isMobileView = window.innerWidth < 768;
-      const additionalScroll = window.innerHeight * (isMobileView ? 0.24 : 0.1);
-      const target = baseTarget + additionalScroll;
+    const headerOffset = window.innerWidth < 768 ? 96 : 108;
+    const trustbarRect = trustbar?.getBoundingClientRect();
+    const cardRect = card.getBoundingClientRect();
+    const trustbarHeight = trustbarRect ? trustbarRect.height : 0;
+    const cardHeight = cardRect.height;
+    const centerOffset = (window.innerHeight - cardHeight) / 2;
+    const baseTarget =
+      cardRect.top +
+      window.pageYOffset -
+      headerOffset -
+      trustbarHeight -
+      centerOffset;
 
-      window.scrollTo({ top: target, behavior: 'smooth' });
-    }
+    const isMobileView = window.innerWidth < 768;
+    const additionalScroll = window.innerHeight * (isMobileView ? 0.24 : 0.1);
+    targetRef.current = baseTarget + additionalScroll;
+  }, []);
+
+  React.useLayoutEffect(() => {
+    computeTarget();
+    window.addEventListener('resize', computeTarget);
+    return () => window.removeEventListener('resize', computeTarget);
+  }, [computeTarget]);
+
+  const scrollToBenefits = () => {
+    window.scrollTo({ top: targetRef.current, behavior: 'smooth' });
   };
 
   return (

--- a/src/hooks/use-mobile.ts
+++ b/src/hooks/use-mobile.ts
@@ -9,20 +9,16 @@ export const useIsMobile = (breakpoint: number = 768): boolean => {
   const [isMobile, setIsMobile] = useState<boolean>(false);
 
   useEffect(() => {
-    // Função para verificar se é mobile
-    const checkIsMobile = () => {
-      setIsMobile(window.innerWidth < breakpoint);
+    const mql = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
+    const onChange = (e: MediaQueryListEvent) => {
+      setIsMobile(e.matches);
     };
 
-    // Verificar no primeiro render
-    checkIsMobile();
+    setIsMobile(mql.matches);
+    mql.addEventListener('change', onChange);
 
-    // Adicionar listener para mudanças de tamanho
-    window.addEventListener('resize', checkIsMobile);
-
-    // Limpar listener quando o componente desmontar
     return () => {
-      window.removeEventListener('resize', checkIsMobile);
+      mql.removeEventListener('change', onChange);
     };
   }, [breakpoint]);
 

--- a/src/hooks/use-mobile.tsx
+++ b/src/hooks/use-mobile.tsx
@@ -27,11 +27,11 @@ export function useIsMobile() {
 
   React.useEffect(() => {
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    const onChange = (e: MediaQueryListEvent) => {
+      setIsMobile(e.matches)
     }
     mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    setIsMobile(mql.matches)
     return () => mql.removeEventListener("change", onChange)
   }, [])
 


### PR DESCRIPTION
## Summary
- update mobile detection hooks to rely on `matchMedia`
- observe `DesktopHeader` height via `ResizeObserver`
- precompute scroll offset in `Hero` to avoid repeated layout reads

## Testing
- `npm run lint` *(fails: unexpected any, fast refresh warnings)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_687693731d1c8320a320f6564911578b