### PR TITLE
Adjust footer widget layout

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -70,21 +70,22 @@ const Footer: React.FC = () => {
                     <path d="M12.525.02c1.31-.02 2.61-.01 3.91-.02.08 1.53.63 3.09 1.75 4.17 1.12 1.11 2.7 1.62 4.24 1.79v4.03c-1.44-.05-2.89-.35-4.2-.97-.57-.26-1.1-.59-1.62-.93-.01 2.92.01 5.84-.02 8.75-.08 1.4-.54 2.79-1.35 3.94-1.31 1.92-3.58 3.17-5.91 3.21-1.43.08-2.86-.31-4.08-1.03-2.02-1.19-3.44-3.37-3.65-5.71-.02-.5-.03-1-.01-1.49.18-1.9 1.12-3.72 2.58-4.96 1.66-1.44 3.98-2.13 6.15-1.72.02 1.48-.04 2.96-.04 4.44-.99-.32-2.15-.23-3.02.37-.63.41-1.11 1.04-1.36 1.75-.21.51-.15 1.07-.14 1.61.24 1.64 1.82 3.02 3.5 2.87 1.12-.01 2.19-.66 2.77-1.61.19-.33.4-.67.41-1.06.1-1.79.06-3.57.07-5.36.01-4.03-.01-8.05.02-12.07z" />
                   </svg>
                 </a>
-                <button 
-                  onClick={scrollToTop} 
-                  className="text-white hover:text-white/70 transition-colors" 
+                <button
+                  onClick={scrollToTop}
+                  className="text-white hover:text-white/70 transition-colors"
                   aria-label="Voltar ao topo"
                 >
                   <ChevronUp className="w-4 h-4" />
                 </button>
               </div>
             </div>
-            
-            {/* Layout desktop: horizontal */}
-            <div className="hidden md:flex justify-end items-center gap-4 mb-4">
-              <a href="https://www.facebook.com/LibraCreditoOficial/" target="_blank" rel="noopener noreferrer" className="text-white hover:text-white/70 transition-colors" aria-label="Facebook">
-                <Facebook className="w-7 h-7" />
-              </a>
+
+            {/* Layout desktop: ícones, selo e botão empilhados */}
+            <div className="hidden md:flex flex-col items-end gap-4">
+              <div className="flex justify-end items-center gap-4">
+                <a href="https://www.facebook.com/LibraCreditoOficial/" target="_blank" rel="noopener noreferrer" className="text-white hover:text-white/70 transition-colors" aria-label="Facebook">
+                  <Facebook className="w-7 h-7" />
+                </a>
               <a href="https://www.instagram.com/libracredito/" target="_blank" rel="noopener noreferrer" className="text-white hover:text-white/70 transition-colors" aria-label="Instagram">
                 <Instagram className="w-7 h-7" />
               </a>
@@ -94,27 +95,29 @@ const Footer: React.FC = () => {
               <a href="https://www.youtube.com/channel/UCXpuj7LlTLT_kdbwwJHS0qA" target="_blank" rel="noopener noreferrer" className="text-white hover:text-white/70 transition-colors" aria-label="YouTube">
                 <Youtube className="w-7 h-7" />
               </a>
-              <a href="https://www.tiktok.com/@libracredito" target="_blank" rel="noopener noreferrer" className="text-white hover:text-white/70 transition-colors" aria-label="TikTok">
-                <svg viewBox="0 0 24 24" className="w-7 h-7 fill-current" xmlns="http://www.w3.org/2000/svg">
-                  <title>TikTok</title>
-                  <path d="M12.525.02c1.31-.02 2.61-.01 3.91-.02.08 1.53.63 3.09 1.75 4.17 1.12 1.11 2.7 1.62 4.24 1.79v4.03c-1.44-.05-2.89-.35-4.2-.97-.57-.26-1.1-.59-1.62-.93-.01 2.92.01 5.84-.02 8.75-.08 1.4-.54 2.79-1.35 3.94-1.31 1.92-3.58 3.17-5.91 3.21-1.43.08-2.86-.31-4.08-1.03-2.02-1.19-3.44-3.37-3.65-5.71-.02-.5-.03-1-.01-1.49.18-1.9 1.12-3.72 2.58-4.96 1.66-1.44 3.98-2.13 6.15-1.72.02 1.48-.04 2.96-.04 4.44-.99-.32-2.15-.23-3.02.37-.63.41-1.11 1.04-1.36 1.75-.21.51-.15 1.07-.14 1.61.24 1.64 1.82 3.02 3.5 2.87 1.12-.01 2.19-.66 2.77-1.61.19-.33.4-.67.41-1.06.1-1.79.06-3.57.07-5.36.01-4.03-.01-8.05.02-12.07z" />
-                </svg>
-              </a>
+                <a href="https://www.tiktok.com/@libracredito" target="_blank" rel="noopener noreferrer" className="text-white hover:text-white/70 transition-colors" aria-label="TikTok">
+                  <svg viewBox="0 0 24 24" className="w-7 h-7 fill-current" xmlns="http://www.w3.org/2000/svg">
+                    <title>TikTok</title>
+                    <path d="M12.525.02c1.31-.02 2.61-.01 3.91-.02.08 1.53.63 3.09 1.75 4.17 1.12 1.11 2.7 1.62 4.24 1.79v4.03c-1.44-.05-2.89-.35-4.2-.97-.57-.26-1.1-.59-1.62-.93-.01 2.92.01 5.84-.02 8.75-.08 1.4-.54 2.79-1.35 3.94-1.31 1.92-3.58 3.17-5.91 3.21-1.43.08-2.86-.31-4.08-1.03-2.02-1.19-3.44-3.37-3.65-5.71-.02-.5-.03-1-.01-1.49.18-1.9 1.12-3.72 2.58-4.96 1.66-1.44 3.98-2.13 6.15-1.72.02 1.48-.04 2.96-.04 4.44-.99-.32-2.15-.23-3.02.37-.63.41-1.11 1.04-1.36 1.75-.21.51-.15 1.07-.14 1.61.24 1.64 1.82 3.02 3.5 2.87 1.12-.01 2.19-.66 2.77-1.61.19-.33.4-.67.41-1.06.1-1.79.06-3.57.07-5.36.01-4.03-.01-8.05.02-12.07z" />
+                  </svg>
+                </a>
+              </div>
+              <div className="mt-2">
+                <RASeal />
+              </div>
+              <button
+                onClick={scrollToTop}
+                className="flex items-center gap-2 text-white/80 hover:text-white transition-colors text-sm"
+                aria-label="Voltar ao topo"
+              >
+                <ChevronUp className="w-4 h-4" />
+                <span>Voltar ao topo</span>
+              </button>
             </div>
-
-            {/* Botão Voltar ao Topo - apenas desktop */}
-            <button
-              onClick={scrollToTop}
-              className="hidden md:flex items-center gap-1 md:gap-2 ml-auto text-white/80 hover:text-white transition-colors text-xs md:text-sm"
-              aria-label="Voltar ao topo"
-            >
-              <ChevronUp className="w-3 h-3 md:w-4 md:h-4" />
-              <span className="hidden md:inline">Voltar ao topo</span>
-            </button>
           </div>
 
-          {/* Selo Reclame Aqui - posicionado à direita no desktop e centralizado no mobile */}
-          <div className="col-span-3 md:col-span-1 md:col-start-3 flex justify-center md:justify-end mt-4">
+          {/* Selo Reclame Aqui - apenas mobile */}
+          <div className="col-span-3 md:hidden flex justify-center mt-4">
             <RASeal />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- move RASeal widget inside the desktop social links container
- show RASeal separately only on mobile
- relocate "Voltar ao topo" button beneath the widget on desktop

## Testing
- `npm run lint` *(fails: @typescript-eslint errors)*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6876a4758d848320b4a46decd58babd5