### PR TITLE
Refatora Hero.tsx para evitar reflow forçado

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -18,39 +18,29 @@ const Hero: React.FC = () => {
     navigate('/vantagens');
   };
 
-  const targetRef = React.useRef<number>(0);
-
-  const computeTarget = React.useCallback(() => {
+  const scrollToBenefits = () => {
     const card = document.getElementById('capital-giro-card');
     const trustbar = document.getElementById('trustbar');
-    if (!card) return;
+    if (card) {
+      const headerOffset = window.innerWidth < 768 ? 96 : 108;
+      const trustbarRect = trustbar?.getBoundingClientRect();
+      const cardRect = card.getBoundingClientRect();
+      const trustbarHeight = trustbarRect ? trustbarRect.height : 0;
+      const cardHeight = cardRect.height;
+      const centerOffset = (window.innerHeight - cardHeight) / 2;
+      const baseTarget =
+        cardRect.top +
+        window.pageYOffset -
+        headerOffset -
+        trustbarHeight -
+        centerOffset;
 
-    const headerOffset = window.innerWidth < 768 ? 96 : 108;
-    const trustbarRect = trustbar?.getBoundingClientRect();
-    const cardRect = card.getBoundingClientRect();
-    const trustbarHeight = trustbarRect ? trustbarRect.height : 0;
-    const cardHeight = cardRect.height;
-    const centerOffset = (window.innerHeight - cardHeight) / 2;
-    const baseTarget =
-      cardRect.top +
-      window.pageYOffset -
-      headerOffset -
-      trustbarHeight -
-      centerOffset;
+      const isMobileView = window.innerWidth < 768;
+      const additionalScroll = window.innerHeight * (isMobileView ? 0.24 : 0.1);
+      const target = baseTarget + additionalScroll;
 
-    const isMobileView = window.innerWidth < 768;
-    const additionalScroll = window.innerHeight * (isMobileView ? 0.24 : 0.1);
-    targetRef.current = baseTarget + additionalScroll;
-  }, []);
-
-  React.useLayoutEffect(() => {
-    computeTarget();
-    window.addEventListener('resize', computeTarget);
-    return () => window.removeEventListener('resize', computeTarget);
-  }, [computeTarget]);
-
-  const scrollToBenefits = () => {
-    window.scrollTo({ top: targetRef.current, behavior: 'smooth' });
+      window.scrollTo({ top: target, behavior: 'smooth' });
+    }
   };
 
   return (


### PR DESCRIPTION
- Remove o `useLayoutEffect` que calculava a posição de rolagem no carregamento do componente.
- Move a lógica de cálculo para dentro do manipulador de evento `onClick`, evitando o reflow forçado durante a renderização inicial.