### PR TITLE
Fix bar animation initial state

### DIFF
--- a/src/pages/Vantagens.tsx
+++ b/src/pages/Vantagens.tsx
@@ -258,8 +258,8 @@ const Vantagens: React.FC = () => {
                             item.destaque ? 'bg-libra-navy' : 'bg-red-400/70'
                           }`}
                           style={{
-                            width: `${animatedValues[index] || (isTableVisible ? ((item.taxa / maxTaxa) * 100) : 0)}%`,
-                            minWidth: animatedValues[index] || (isTableVisible ? '2px' : '0px')
+                            width: `${animatedValues[index] ?? 0}%`,
+                            minWidth: animatedValues[index] ? '2px' : '0px'
                           }}
                         />
                       </div>


### PR DESCRIPTION
## Summary
- prevent comparison bar graph from showing full width before animation

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: Unexpected any warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6876abb840f0832095a45dc8b7843271