### PR TITLE
Fix high quality header logo

### DIFF
--- a/src/components/DesktopHeader.tsx
+++ b/src/components/DesktopHeader.tsx
@@ -105,10 +105,10 @@ const DesktopHeader: React.FC<DesktopHeaderProps> = ({ onPortalClientes, onSimul
           <div className="flex items-center justify-between h-[62px] lg:h-[82px]">
             {/* Logo e slogan */}
             <div className="flex items-center gap-6">
-              <Link to="/" className="flex items-center">
+              <Link to="/" className="flex items-center tap-transparent">
                 <div className="h-[62px] lg:h-[82px] overflow-hidden flex items-center">
                   <img
-                    src="/images/logos/libra-logo.png"
+                    src="/logo-libra.png"
                     alt="Libra Crédito - Home Equity com garantia de imóvel"
                     className="h-full w-auto"
                   />

--- a/src/components/MobileHeader.tsx
+++ b/src/components/MobileHeader.tsx
@@ -65,10 +65,10 @@ const MobileHeader: React.FC<MobileHeaderProps> = ({ onPortalClientes, onSimulat
       <div className="container mx-auto px-4">
         <div className="flex items-center justify-between h-16">
           <div className="flex items-center">
-            <Link to="/" aria-label="Página inicial da Libra Crédito">
+            <Link to="/" aria-label="Página inicial da Libra Crédito" className="tap-transparent">
               <div className="h-12 overflow-hidden flex items-center">
                 <img
-                  src="/images/logos/libra-logo.png"
+                  src="/logo-libra.png"
                   alt="Libra Crédito"
                   className="h-full w-auto"
                 />


### PR DESCRIPTION
## Summary
- improve desktop header logo quality
- improve mobile header logo quality
- disable iOS tap highlight on logo links

## Testing
- `npm run lint` *(fails: Unexpected any errors, etc.)*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6876aff9182c8320b7f3498ef213af9b