### PR TITLE
Fix logo size on iOS tap

### DIFF
--- a/src/components/DesktopHeader.tsx
+++ b/src/components/DesktopHeader.tsx
@@ -110,7 +110,7 @@ const DesktopHeader: React.FC<DesktopHeaderProps> = ({ onPortalClientes, onSimul
                   <img
                     src="/logo-libra.png"
                     alt="Libra Crédito - Home Equity com garantia de imóvel"
-                    className="h-full w-auto"
+                    className="h-full w-auto pointer-events-none"
                   />
                 </div>
               </Link>

--- a/src/components/MobileHeader.tsx
+++ b/src/components/MobileHeader.tsx
@@ -70,7 +70,7 @@ const MobileHeader: React.FC<MobileHeaderProps> = ({ onPortalClientes, onSimulat
                 <img
                   src="/logo-libra.png"
                   alt="Libra Crédito"
-                  className="h-full w-auto"
+                  className="h-full w-auto pointer-events-none"
                 />
               </div>
             </Link>

--- a/src/components/SimpleMobileHeader.tsx
+++ b/src/components/SimpleMobileHeader.tsx
@@ -41,7 +41,7 @@ const SimpleMobileHeader: React.FC<SimpleMobileHeaderProps> = ({ onPortalCliente
             <ImageOptimizer
               src="/images/logos/libra-logo.png"
               alt="Libra Crédito - Simulação de crédito com garantia de imóvel"
-              className="h-20 w-auto transform scale-[1.25]"
+              className="h-20 w-auto transform scale-[1.25] pointer-events-none"
               aspectRatio={1}
               priority={true}
               style={{


### PR DESCRIPTION
## Summary
- prevent the header logos from shrinking when tapped on iOS by disabling pointer events on the `<img>` tags

## Testing
- `npm run lint` *(fails: 67 errors, 26 warnings)*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6876b5e90e288320bcdc7a6de7dff8b0