### PR TITLE
Increase logo height on top band

### DIFF
--- a/src/components/LogoBand.tsx
+++ b/src/components/LogoBand.tsx
@@ -8,7 +8,7 @@ const LogoBand: React.FC = () => {
         <ImageOptimizer
           src="/images/logos/libra-logo.png"
           alt="Libra Crédito"
-          className="h-[90%] w-auto"
+          className="h-full w-auto"
           aspectRatio={1}
           priority={false}
         />


### PR DESCRIPTION
## Summary
- use full available height for the blue logo band

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6876bccb3f748320970aab34ccddd492