### PR TITLE
Increase logo size on top band

### DIFF
--- a/src/components/LogoBand.tsx
+++ b/src/components/LogoBand.tsx
@@ -3,12 +3,12 @@ import ImageOptimizer from '@/components/ImageOptimizer';
 
 const LogoBand: React.FC = () => {
   return (
-    <div className="w-full bg-[#003399] flex justify-center py-4">
-      <div className="flex items-center h-20">
+    <div className="w-full bg-[#003399] flex justify-center h-24">
+      <div className="flex items-center h-full">
         <ImageOptimizer
           src="/images/logos/libra-logo.png"
           alt="Libra Crédito"
-          className="h-[90%] w-auto"
+          className="h-full w-auto"
           aspectRatio={1}
           priority={false}
         />


### PR DESCRIPTION
## Summary
- adjust the logo band height and remove padding so the logo fills the area

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6876bccb3f748320970aab34ccddd492