### PR TITLE
Update simulation button styling

### DIFF
--- a/src/components/DesktopHeader.tsx
+++ b/src/components/DesktopHeader.tsx
@@ -145,11 +145,11 @@ const DesktopHeader: React.FC<DesktopHeaderProps> = ({ onPortalClientes, onSimul
                 Portal de Clientes
               </Button>
               
-              <Button 
+              <Button
                 onClick={onSimulateNow}
                 size="sm"
                 aria-label="Simular crédito agora"
-                className="px-4 lg:px-6 font-bold bg-red-600 text-white hover:bg-red-700 shadow-lg hover:shadow-xl transition-all duration-200 hover:-translate-y-0.5 text-sm lg:text-base"
+                className="px-4 lg:px-6 font-bold bg-[#ff6666] text-white hover:bg-[#ff5a5a] shadow-lg hover:shadow-xl transition-all duration-200 hover:-translate-y-0.5 text-sm lg:text-base"
               >
                 Simule Agora
               </Button>

--- a/src/components/MobileHeader.tsx
+++ b/src/components/MobileHeader.tsx
@@ -77,8 +77,8 @@ const MobileHeader: React.FC<MobileHeaderProps> = ({ onPortalClientes, onSimulat
           </div>
 
           <div className="flex items-center gap-2">
-            <Button 
-              className="min-h-[40px] px-4 text-sm font-semibold bg-red-600 text-white hover:bg-red-700 shadow-md"
+            <Button
+              className="min-h-[40px] px-4 text-sm font-bold bg-[#ff6666] text-white hover:bg-[#ff5a5a] shadow-md"
               size="sm"
               onClick={onSimulateNow}
               aria-label="Simular crédito agora"

--- a/src/components/SimpleMobileHeader.tsx
+++ b/src/components/SimpleMobileHeader.tsx
@@ -49,10 +49,10 @@ const SimpleMobileHeader: React.FC<SimpleMobileHeaderProps> = ({ onPortalCliente
         {/* Right side buttons */}
         <div className="flex items-center gap-2">
           {/* Simular Button - destaque principal */}
-          <Button 
+          <Button
             onClick={handleSimulate}
             size="sm"
-            className="bg-red-600 text-white hover:bg-red-700 text-sm px-4 py-3 h-11 min-h-[44px]"
+            className="bg-[#ff6666] text-white hover:bg-[#ff5a5a] text-sm px-4 py-3 h-11 min-h-[44px] font-bold"
             aria-label="Ir para simulação de empréstimo"
           >
             Simular


### PR DESCRIPTION
## Summary
- adjust header "Simulação" buttons to use #ff6666
- ensure bold text on mobile headers

## Testing
- `npm run lint` *(fails: 93 problems)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68793a4954588320b664a09612df0c7d