### PR TITLE
Fix iOS popup and video interactions

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -24,7 +24,6 @@ import React, { memo, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useDevice } from '@/hooks/useDevice';
 import DesktopHeader from './DesktopHeader';
-import MobileHeader from './MobileHeader';
 import SimpleMobileHeader from './SimpleMobileHeader';
 import {
   Dialog,
@@ -41,7 +40,15 @@ const Header: React.FC = memo(() => {
   const [isInfoPopupOpen, setIsInfoPopupOpen] = useState(false);
   const location = useLocation();
   const navigate = useNavigate();
-  const { isMobile, isDesktop } = useDevice();
+  const { isMobile } = useDevice();
+
+  useEffect(() => {
+    if (isInfoPopupOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+  }, [isInfoPopupOpen]);
 
   // Controla quando mostrar o popup baseado na página atual
   useEffect(() => {

--- a/src/components/OptimizedYouTube.tsx
+++ b/src/components/OptimizedYouTube.tsx
@@ -95,12 +95,19 @@ const OptimizedYouTube: React.FC<OptimizedYouTubeProps> = ({
         <iframe
           ref={iframeRef}
           className="absolute inset-0 w-full h-full"
-          src={`https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&rel=0&modestbranding=1&preload=metadata`}
+          src={`https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&rel=0&modestbranding=1&playsinline=1&enablejsapi=1`}
           title={title}
           frameBorder="0"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
           allowFullScreen
           loading="lazy"
+          onLoad={() => {
+            iframeRef.current?.contentWindow?.postMessage(
+              JSON.stringify({ event: 'command', func: 'playVideo', args: [] }),
+              '*'
+            );
+          }}
+          playsInline
         />
       )}
     </div>

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -9,6 +9,8 @@ const ScrollToTop = () => {
       top: 0,
       behavior: 'smooth'
     });
+    document.body.scrollTop = 0;
+    document.documentElement.scrollTop = 0;
   }, [pathname]);
 
   return null;


### PR DESCRIPTION
## Summary
- keep scroll position when navigating to a new page
- lock page scroll while popup is open
- improve autoplay on iOS by forcing play message
- ensure newline at EOF for ScrollToTop

## Testing
- `npm run lint` *(fails: 67 errors, 26 warnings)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_687977402a348320acf5df84d2ce87c5