### PR TITLE
Standardize CTA buttons

### DIFF
--- a/src/components/ui/HeroButton.tsx
+++ b/src/components/ui/HeroButton.tsx
@@ -8,13 +8,13 @@ const HeroButton = React.forwardRef<
   }
 >(({ className, variant = 'primary', ...props }, ref) => {
   const baseClasses =
-    'w-full rounded-lg px-6 py-3 text-sm sm:px-8 sm:py-4 sm:text-base font-bold transition-all duration-300 ease-in-out transform focus:outline-none focus:ring-4 focus:ring-opacity-50';
+    'w-full cta-button px-6 py-3 text-sm sm:px-8 sm:py-4 sm:text-base font-bold';
 
   const variantClasses = {
     primary:
-      'bg-gradient-to-r from-[#003399] to-[#0055CC] text-white shadow-lg hover:shadow-xl hover:scale-105 focus:ring-[#003399]',
+      'bg-gradient-to-r from-[#003399] to-[#0055CC] text-white',
     secondary:
-      'bg-transparent border-2 border-[#003399] text-[#003399] hover:bg-[#003399] hover:text-white focus:ring-[#003399]',
+      'bg-transparent border-2 border-[#003399] text-[#003399] hover:bg-[#003399] hover:text-white',
   };
 
   return (

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -6,17 +6,18 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium ring-offset-background shadow-sm transition-colors transition-transform duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:shadow-md disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 min-h-[48px]",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default:
+          "bg-primary text-primary-foreground hover:bg-primary/90 hover:scale-105 hover:shadow-md",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
           "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80 hover:scale-105 hover:shadow-md",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
         // Melhorando o contraste para acessibilidade

--- a/src/index.css
+++ b/src/index.css
@@ -126,6 +126,29 @@
   .mobile-button-secondary {
     @apply mobile-button bg-gray-100 text-gray-900 active:bg-gray-200;
   }
+
+  /* Reusable CTA styles */
+  .cta-button {
+    @apply rounded-lg shadow-sm transition-colors transition-transform duration-200 ease-in-out focus-visible:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-libra-blue focus-visible:ring-offset-2;
+  }
+
+  .cta-button:hover {
+    @apply scale-105 shadow-md;
+  }
+
+  @media (max-width: 767px) {
+    .cta-button {
+      @apply min-h-[48px];
+    }
+  }
+
+  .cta-primary {
+    @apply cta-button bg-libra-blue text-white hover:bg-libra-blue/90;
+  }
+
+  .cta-secondary {
+    @apply cta-button bg-gray-100 text-gray-900 hover:bg-gray-200;
+  }
   
   /* Mobile Input Styles */
   .mobile-input {
@@ -297,13 +320,13 @@
   }
   
   /* Aumentar o espaçamento e tamanho mínimo para áreas de toque */
-  button, 
-  [role="button"], 
-  a, 
-  input[type="submit"], 
-  input[type="button"], 
+  button,
+  [role="button"],
+  a,
+  input[type="submit"],
+  input[type="button"],
   input[type="reset"] {
-    @apply min-h-[44px] min-w-[44px];
+    @apply min-h-[48px] min-w-[44px];
     -webkit-tap-highlight-color: transparent;
   }
   


### PR DESCRIPTION
## Summary
- add reusable `.cta-button`, `.cta-primary`, `.cta-secondary` classes
- enlarge mobile touch targets to 48px
- add consistent hover/focus effects to primary and secondary buttons
- use shared CTA styles in HeroButton component

## Testing
- `npm run lint` *(fails: unexpected any, require-imports)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_687a2b3d8794832093e3a70cb6272aaa