### PR TITLE
Fix scroll reset after navigation

### DIFF
--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -5,13 +5,10 @@ const ScrollToTop = () => {
   const { pathname } = useLocation();
 
   useEffect(() => {
-    window.scrollTo({
-      top: 0,
-      behavior: 'smooth'
-    });
+    setTimeout(() => window.scrollTo(0, 0), 50);
   }, [pathname]);
 
   return null;
 };
 
-export default ScrollToTop; 
+export default ScrollToTop;


### PR DESCRIPTION
## Summary
- update ScrollToTop behavior to always scroll to top after route change

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_687a2dc9c69083208a817f66962cbcf1