### PR TITLE
Add critical CSS extraction step

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,11 +200,18 @@
     <link rel="preload" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&display=swap" rel="stylesheet"></noscript>
 
-    <!-- Async CSS to reduce render blocking -->
-    <link rel="stylesheet" href="/src/index.css" media="print" onload="this.media='all'">
+    <!-- Critical CSS inlined during build -->
+    <style id="critical-css">
+      /* Critical CSS will be injected here by the build step */
+    </style>
+
+    <!-- Non‑blocking main stylesheet -->
+    <link rel="preload" as="style" href="/assets/index.css" onload="this.rel='stylesheet'">
+    <noscript><link rel="stylesheet" href="/assets/index.css"></noscript>
+
+    <!-- Remaining stylesheets -->
     <link rel="stylesheet" href="/src/styles/minimal-premium.css" media="print" onload="this.media='all'">
     <noscript>
-      <link rel="stylesheet" href="/src/index.css" />
       <link rel="stylesheet" href="/src/styles/minimal-premium.css" />
     </noscript>
     

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@types/uuid": "^9.0.7",
         "@vitejs/plugin-react-swc": "^3.5.0",
         "autoprefixer": "^10.4.20",
+        "critters": "^0.0.23",
         "cssnano": "^6.0.0",
         "eslint": "^9.9.0",
         "eslint-plugin-react-hooks": "^5.1.0-rc.0",
@@ -3369,6 +3370,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/critters": {
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/critters/-/critters-0.0.23.tgz",
+      "integrity": "sha512-/MCsQbuzTPA/ZTOjjyr2Na5o3lRpr8vd0MZE8tMP0OBNg/VrLxWHteVKalQ8KR+fBmUadbJLdoyEz9sT+q84qg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "css-select": "^5.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.2",
+        "htmlparser2": "^8.0.2",
+        "postcss": "^8.4.23",
+        "postcss-media-query-parser": "^0.2.3"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4457,6 +4474,26 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5443,6 +5480,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/postcss-media-query-parser": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
+      "integrity": "sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/postcss-merge-longhand": {
       "version": "6.0.5",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:critical": "vite build && node scripts/extract-critical.mjs",
     "build:dev": "vite build --mode development",
     "build:prod": "npm install && vite build",
     "lint": "eslint .",
@@ -46,6 +47,7 @@
     "@types/uuid": "^9.0.7",
     "@vitejs/plugin-react-swc": "^3.5.0",
     "autoprefixer": "^10.4.20",
+    "critters": "^0.0.23",
     "cssnano": "^6.0.0",
     "eslint": "^9.9.0",
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",

--- a/scripts/extract-critical.mjs
+++ b/scripts/extract-critical.mjs
@@ -1,0 +1,11 @@
+import { readFile, writeFile } from 'fs/promises';
+import Critters from 'critters';
+
+const critters = new Critters({
+  path: 'dist'
+});
+
+const html = await readFile('dist/index.html', 'utf8');
+const processed = await critters.process(html);
+await writeFile('dist/index.html', processed);
+


### PR DESCRIPTION
## Summary
- inline a placeholder for critical CSS and load main stylesheet non-blocking
- add a build:critical script to extract critical CSS with Critters
- include critters as a dev dependency and provide helper script

## Testing
- `npm run lint` *(fails: Unexpected any)*
- `npm run build` 
- `npm run build:critical`

------
https://chatgpt.com/codex/tasks/task_e_687a40a322b08320ba1a7ef8b81272b8