### PR TITLE
Add CSS size check with visualizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^4.5.3"
+    "vite": "^4.5.3",
+    "rollup-plugin-visualizer": "^6.0.3"
   },
   "optionalDependencies": {
     "@rollup/rollup-darwin-arm64": "^4.0.0",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,12 +2,13 @@
 import type { Config } from "tailwindcss";
 
 export default {
-	content: [
-		"./pages/**/*.{ts,tsx}",
-		"./components/**/*.{ts,tsx}",
-		"./app/**/*.{ts,tsx}",
-		"./src/**/*.{ts,tsx}",
-	],
+        content: [
+                "./index.html",
+                "./pages/**/*.{ts,tsx}",
+                "./components/**/*.{ts,tsx}",
+                "./app/**/*.{ts,tsx}",
+                "./src/**/*.{js,jsx,ts,tsx}",
+        ],
 	prefix: "",
 	theme: {
 		container: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { componentTagger } from "lovable-tagger";
+import { visualizer } from "rollup-plugin-visualizer";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
@@ -25,6 +26,23 @@ export default defineConfig(({ mode }) => ({
             ? full
             : `<link rel="stylesheet" href="${href}" media="print" onload="this.media='all'">`;
         });
+      }
+    },
+    visualizer({ filename: './dist/stats.html', gzipSize: true }),
+    {
+      name: 'check-css-size',
+      enforce: 'post',
+      generateBundle(_, bundle) {
+        for (const file of Object.values(bundle)) {
+          if (file.type === 'asset' && file.fileName.endsWith('.css')) {
+            const size = Buffer.byteLength(file.source as string | Uint8Array);
+            if (size > 20 * 1024) {
+              this.error(`CSS asset ${file.fileName} is ${(size / 1024).toFixed(2)} KB, exceeding 20 KB`);
+            } else {
+              this.warn(`CSS asset ${file.fileName} size ${(size / 1024).toFixed(2)} KB`);
+            }
+          }
+        }
       }
     }
   ].filter(Boolean),


### PR DESCRIPTION
## Summary
- extend Tailwind content paths to include index.html and JS/TSX files
- install rollup-plugin-visualizer and integrate into Vite
- add build-time CSS size check to fail if CSS assets exceed 20 KB

## Testing
- `npm run build` *(fails because CSS asset index-caf888b1.css is 121.16 KB)*

------
https://chatgpt.com/codex/tasks/task_e_687a40a767b88320951e154e83ca6af6