### PR TITLE
Update preload priority for video thumbnail

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     <!-- Preload LCP Images -->
     <link rel="preload" href="/images/video-thumbnail.webp" as="image" fetchpriority="high">
     <link rel="preload" href="/images/logos/libra-logo.webp" as="image" fetchpriority="high">
+    <link rel="preload" as="image" href="/images/video-thumbnail.jpg" fetchpriority="high">
     
     <!-- Prefetch Important Pages -->
     <link rel="prefetch" href="/simulacao">


### PR DESCRIPTION
## Summary
- prioritize `video-thumbnail.jpg` by preloading it in the head

## Testing
- `npm run lint` *(fails: 69 errors, 26 warnings)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_687a4086d07c83209e8f5f6b713b1630