### PR TITLE
Fix iOS modal close and autoplay

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -89,7 +89,11 @@ const Header: React.FC = memo(() => {
       )}
 
       {/* Popup informativo centralizado - apenas para páginas específicas */}
-      <Dialog open={isInfoPopupOpen} onOpenChange={setIsInfoPopupOpen}>
+      <Dialog
+        open={isInfoPopupOpen}
+        onOpenChange={setIsInfoPopupOpen}
+        onInteractOutside={(e) => e.preventDefault()}
+      >
         <DialogContent className="fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 sm:rounded-lg">
           <DialogHeader>
             <DialogTitle className="flex items-center text-libra-navy text-base">

--- a/src/components/OptimizedYouTube.tsx
+++ b/src/components/OptimizedYouTube.tsx
@@ -119,6 +119,7 @@ const OptimizedYouTube: React.FC<OptimizedYouTubeProps> = ({
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
           allowFullScreen
           loading="lazy"
+          playsInline
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- close info popup only via button
- let YouTube videos play inline on iPhone

## Testing
- `npm run lint` *(fails: 69 errors)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_687a5bcb9ab883209c04e72d3c923fda