### PR TITLE
Require Supabase env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ Use o arquivo: `supabase-setup-complete.sql`
 # Copie o arquivo de exemplo
 cp .env.example .env
 
-# Configure suas variáveis no arquivo .env:
-# - VITE_SUPABASE_URL e VITE_SUPABASE_ANON_KEY (obrigatório)
-# - VITE_WEBHOOK_URL (opcional - para webhook de simulações)
+# Configure suas variáveis no arquivo .env (obrigatório):
+# - `VITE_SUPABASE_URL` e `VITE_SUPABASE_ANON_KEY`
+#   - **Sem valores válidos a aplicação não inicializa**
+# - `VITE_WEBHOOK_URL` (opcional - para webhook de simulações)
 # - Outras conforme necessário
 ```
 
@@ -285,7 +286,7 @@ npm install
 ```
 
 ### **❌ Erro de conexão Supabase**
-1. Verificar URL e API Key em `src/lib/supabase.ts`
+1. Verificar se `VITE_SUPABASE_URL` e `VITE_SUPABASE_ANON_KEY` estão corretos no `.env`
 2. Verificar se tabelas existem no Supabase
 3. Verificar políticas RLS
 

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -20,9 +20,13 @@
 
 import { createClient } from '@supabase/supabase-js';
 
-// Configurações do Supabase - usando variáveis de ambiente com fallback
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || 'https://wprkpdqnmibxphiofoqk.supabase.co';
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY || 'sb_publishable_xjn_ruSWUfyiqoMIrQfcOw_-YVtj5lr';
+// Configurações do Supabase - requer variáveis de ambiente
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error('VITE_SUPABASE_URL e VITE_SUPABASE_ANON_KEY devem estar definidos no ambiente');
+}
 
 // Log para debug (apenas em development)
 if (typeof window !== 'undefined' && import.meta.env.DEV) {


### PR DESCRIPTION
## Summary
- enforce VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY in `supabase.ts`
- clarify README to set these variables

## Testing
- `npm run lint` *(fails: 72 errors, 28 warnings)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_687e3fc03e948320ba347b0b1e6f2f9d