### PR TITLE
Enable strict TypeScript configuration

### DIFF
--- a/src/components/SupabaseDiagnostics.tsx
+++ b/src/components/SupabaseDiagnostics.tsx
@@ -8,7 +8,7 @@ interface DiagnosticResult {
   test: string;
   status: 'success' | 'error' | 'warning';
   message: string;
-  details?: any;
+  details?: unknown;
 }
 
 const SupabaseDiagnostics: React.FC = () => {

--- a/src/components/ui/simple-toast.tsx
+++ b/src/components/ui/simple-toast.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
-interface ToastProps {
+export interface ToastProps {
   id: string;
   title?: string;
   description?: string;

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -14,5 +14,5 @@ export const ToastDescription = ({ children }: { children: React.ReactNode }) =>
 export const ToastClose = () => null;
 export const ToastAction = () => null;
 
-export type ToastProps = any;
-export type ToastActionElement = any;
+export type ToastProps = import("./simple-toast").ToastProps;
+export type ToastActionElement = React.ReactElement;

--- a/src/hooks/useUserJourney.ts
+++ b/src/hooks/useUserJourney.ts
@@ -24,7 +24,7 @@ import { v4 as uuidv4 } from 'uuid';
 import type { UserJourneyData, PageVisit, DeviceInfo } from '@/lib/supabase';
 
 // Lazy loader para evitar carregar Supabase na primeira pintura
-let cachedSupabase: any = null;
+let cachedSupabase: typeof import("@/lib/supabase").supabaseApi | null = null;
 async function getSupabaseApi() {
   if (!cachedSupabase) {
     cachedSupabase = (await import('@/lib/supabase')).supabaseApi;
@@ -41,7 +41,7 @@ interface UserJourneyHook {
   sessionId: string;
   isTracking: boolean;
   trackPageVisit: (url?: string) => void;
-  trackSimulation: (simulationData: any) => void;
+  trackSimulation: (simulationData: unknown) => void;
   getJourneyData: () => UserJourneyData | null;
   updateTimeOnSite: () => void;
 }
@@ -155,7 +155,7 @@ export function useUserJourney(): UserJourneyHook {
       const supabaseApi = await getSupabaseApi();
       try {
         existingJourney = await supabaseApi.getUserJourney(sessionId);
-      } catch (getError: any) {
+      } catch (getError: unknown) {
         // Apenas log em desenvolvimento, não desabilitar o tracking ainda
         if (process.env.NODE_ENV === 'development') {
           console.warn('Could not fetch existing journey:', getError?.message);
@@ -271,7 +271,7 @@ export function useUserJourney(): UserJourneyHook {
   }, [sessionId, isTracking]);
   
   // Função para rastrear simulação
-  const trackSimulation = useCallback((simulationData: any) => {
+  const trackSimulation = useCallback((simulationData: unknown) => {
     if (!sessionId) return;
     
     console.log('Tracking simulação:', { sessionId, simulationData });

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -16,10 +16,10 @@
     "resolveJsonModule": true,
 
     /* Linting */
-    "strict": false,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "noImplicitAny": false,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitAny": true,
     "noFallthroughCasesInSwitch": false,
 
     "baseUrl": ".",


### PR DESCRIPTION
## Summary
- enable TypeScript strict mode and unused checks
- export `ToastProps` type and re‑use in `toast.tsx`
- tighten types in `useUserJourney` hook
- use `unknown` for optional diagnostics details

## Testing
- `npm run typecheck` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e3fbfb2f083208d9d3ee5942122a4