### PR TITLE
Improve LCP by prerendering hero section

### DIFF
--- a/index.html
+++ b/index.html
@@ -286,7 +286,23 @@
   </head>
 
   <body>
-    <div id="root"></div>
+    <!-- Static Hero placeholder to improve LCP -->
+    <div id="root">
+      <section id="hero-placeholder" class="hero-section">
+        <div class="hero-container">
+          <div>
+            <h1 id="hero-heading" class="hero-h1">
+              <span class="block">Crédito com Garantia de Imóvel</span>
+              <span class="block text-green-700">é mais simples na Libra!</span>
+            </h1>
+            <p class="text-lg font-semibold">Crédito inteligente para quem construiu patrimônio.</p>
+          </div>
+          <div class="hero-video" style="contain-intrinsic-size:480px 360px">
+            <img src="/images/thumbnail-libra.webp" alt="Miniatura do Vídeo institucional Libra Crédito" width="480" height="360" class="video-thumbnail" loading="eager" fetchpriority="high" decoding="sync">
+          </div>
+        </div>
+      </section>
+    </div>
     
     
     <script type="module" src="/src/main.tsx"></script>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { createRoot } from 'react-dom/client'
+import { createRoot, hydrateRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css';
 import './styles/overflow-fix.css';
@@ -22,8 +22,16 @@ const renderApp = () => {
   setupAccessibility();
   
   const root = document.getElementById('root');
+  const placeholder = document.getElementById('hero-placeholder');
   if (root) {
-    createRoot(root).render(<App />);
+    if (root.hasChildNodes()) {
+      hydrateRoot(root, <App />);
+    } else {
+      createRoot(root).render(<App />);
+    }
+    if (placeholder) {
+      placeholder.remove();
+    }
   }
 };
 


### PR DESCRIPTION
## Summary
- inline hero markup in `index.html` so the LCP image shows before JS loads
- hydrate existing markup and remove placeholder when React initializes

## Testing
- `npm run lint` *(fails: 68 errors, 230 warnings)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68811209a0a88320b0c1390996905800