### PR TITLE
Reduce header logo size

### DIFF
--- a/src/components/DesktopHeader.tsx
+++ b/src/components/DesktopHeader.tsx
@@ -110,7 +110,7 @@ const DesktopHeader: React.FC<DesktopHeaderProps> = ({ onPortalClientes, onSimul
                   <img
                     src="/images/logo-header.webp"
                     alt="Libra Crédito - Home Equity com garantia de imóvel"
-                    className="h-full w-auto pointer-events-none max-w-none"
+                    className="h-[85%] w-auto pointer-events-none max-w-none"
                     width="150"
                     height="150"
                   />

--- a/src/components/MobileHeader.tsx
+++ b/src/components/MobileHeader.tsx
@@ -27,7 +27,6 @@ import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Menu, X, Info } from 'lucide-react';
-import ImageOptimizer from '@/components/ImageOptimizer';
 
 interface MobileHeaderProps {
   onPortalClientes: () => void;
@@ -70,7 +69,7 @@ const MobileHeader: React.FC<MobileHeaderProps> = ({ onPortalClientes, onSimulat
                 <img
                   src="/images/media/logo-header.png?v=3"
                   alt="Libra Crédito"
-                  className="h-full w-auto pointer-events-none max-w-none"
+                  className="h-[85%] w-auto pointer-events-none max-w-none"
                 />
               </div>
             </Link>

--- a/src/components/SimpleMobileHeader.tsx
+++ b/src/components/SimpleMobileHeader.tsx
@@ -3,7 +3,6 @@ import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useDevice } from '@/hooks/useDevice';
 import { Menu, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import ImageOptimizer from '@/components/ImageOptimizer';
 
 interface SimpleMobileHeaderProps {
   onPortalClientes?: () => void;
@@ -41,7 +40,7 @@ const SimpleMobileHeader: React.FC<SimpleMobileHeaderProps> = ({ onPortalCliente
             <img
               src="/images/media/logo-header.png?v=3"
               alt="Libra Crédito - Simulação de crédito com garantia de imóvel"
-              className="h-full w-auto pointer-events-none max-w-none"
+              className="h-[85%] w-auto pointer-events-none max-w-none"
               width="150"
               height="150"
             />


### PR DESCRIPTION
## Summary
- shrink header logos by 15%
- clean unused imports in mobile headers

## Testing
- `npm run lint` *(fails: several pre-existing errors in temp-files)*
- `npx eslint src/components/MobileHeader.tsx`
- `npx eslint src/components/SimpleMobileHeader.tsx`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68839eff13bc8320abdd0341a8373e26