### PR TITLE
Fix logo preload path in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
     
     <!-- CRITICAL LCP Strategy: Remove image preload to eliminate render blocking -->
     <!-- Video thumbnail now uses instant SVG placeholder for LCP -->
-    <link rel="preload" href="/images/logos/libra-logo.webp" as="image" fetchpriority="high">
+    <link rel="preload" href="/images/logos/libra-logo.png" as="image" fetchpriority="high">
     
     <!-- RADICAL LCP: Force immediate DOM/CSS render -->
     <script>


### PR DESCRIPTION
## Summary
- correct Libra logo preload path

## Testing
- `npm run lint` *(fails: unused vars in temp-files)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6883a1e859408320803b5aa7e9e4f1dc