### PR TITLE
Fix hero video decoding

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
     <!-- CRITICAL LCP Strategy: Remove image preload to eliminate render blocking -->
     <!-- Video thumbnail now uses instant SVG placeholder for LCP -->
     <link rel="preload" href="/images/logos/libra-logo.png" as="image" fetchpriority="high">
+    <link rel="preload" as="image" href="/images/video-thumbnail.webp" fetchpriority="high">
     
     <!-- RADICAL LCP: Force immediate DOM/CSS render -->
     <script>

--- a/src/components/OptimizedYouTube.tsx
+++ b/src/components/OptimizedYouTube.tsx
@@ -52,7 +52,7 @@ const OptimizedYouTube: React.FC<OptimizedYouTubeProps> = ({
             }}
             loading="eager"
             fetchPriority="high"
-            decoding="sync"
+            decoding="async"
           />
 
           {/* Overlay simplificado - usando apenas CSS */}


### PR DESCRIPTION
## Summary
- prioritize the hero video image by preloading its thumbnail
- decode hero thumbnail image asynchronously

## Testing
- `npm run lint` *(fails: 72 errors, 237 warnings)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6883a700f2bc83208223ba29fbcc9312