### PR TITLE
Ajuste logo mobile

### DIFF
--- a/src/components/MobileHeader.tsx
+++ b/src/components/MobileHeader.tsx
@@ -67,7 +67,7 @@ const MobileHeader: React.FC<MobileHeaderProps> = ({ onPortalClientes, onSimulat
             <Link to="/" aria-label="Página inicial da Libra Crédito" className="tap-transparent">
               <div className="h-16 overflow-hidden flex items-center">
                 <img
-                  src="/images/media/logo-header.png?v=3"
+                  src="/images/logo-header.webp"
                   alt="Libra Crédito"
                   className="h-[85%] w-auto pointer-events-none max-w-none"
                 />

--- a/src/components/SimpleMobileHeader.tsx
+++ b/src/components/SimpleMobileHeader.tsx
@@ -38,7 +38,7 @@ const SimpleMobileHeader: React.FC<SimpleMobileHeaderProps> = ({ onPortalCliente
         <Link to="/" className="flex items-center tap-transparent" aria-label="Ir para página inicial da Libra Crédito">
           <div className="h-16 overflow-hidden flex items-center">
             <img
-              src="/images/media/logo-header.png?v=3"
+              src="/images/logo-header.webp"
               alt="Libra Crédito - Simulação de crédito com garantia de imóvel"
               className="h-[85%] w-auto pointer-events-none max-w-none"
               width="150"


### PR DESCRIPTION
## Summary
- match the mobile header logo with the desktop version

## Testing
- `npm test`
- `npm run lint` *(fails: many existing lint errors)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6883bc6781448320b73234e3fab2641a