### PR TITLE
Fix mobile header spacing on home

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -41,8 +41,12 @@ const Index: React.FC = () => {
   return (
     <div className="min-h-screen flex flex-col">
       <Header />
-      
-      <main id="main-content" className="flex-grow pt-header">
+
+      <main
+        id="main-content"
+        data-has-header="true"
+        className="flex-grow pt-header"
+      >
         {/* Faixa Separadora Superior Invertida - Ondas para baixo */}
         <WaveSeparator variant="hero" height="md" inverted />
         


### PR DESCRIPTION
## Summary
- ensure the Home page main section uses the same mobile header offset logic

## Testing
- `npm run lint` *(fails: 72 errors, 241 warnings)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6887977cafdc832093aa08a1cffdc1b1