### PR TITLE
Add preloaded CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,10 @@
     <link rel="preload" href="/fonts/Montserrat-Thin.ttf" as="font" type="font/ttf" crossorigin>
     <link rel="stylesheet" href="/fonts/fonts.css">
 
+    <!-- Preload main stylesheet -->
+    <link rel="preload" href="/assets/css/index.css" as="style" onload="this.rel='stylesheet'">
+    <noscript><link rel="stylesheet" href="/assets/css/index.css"></noscript>
+
     <!-- Early hints for critical resources -->
     <link rel="dns-prefetch" href="https://img.youtube.com">
     <link rel="dns-prefetch" href="https://api-calculos.vercel.app">

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -9,7 +9,7 @@ const urlsToCache = [
   '/index.html',
   '/src/main.tsx',
   '/src/App.tsx',
-  '/src/index.css',
+  '/assets/css/index.css',
   '/lovable-uploads/0be9e819-3b36-4075-944b-cf4835a76b3c.png'
 ];
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx'
-import './index.css';
 import './styles/overflow-fix.css';
 
 // Renderização direta com createRoot para LCP otimizado

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,6 +28,7 @@ export default defineConfig(() => ({
         assetFileNames: (assetInfo) => {
           const info = assetInfo.name.split('.');
           let extType = info[info.length - 1];
+
           if (/png|jpe?g|svg|gif|tiff|bmp|ico|webp|avif/i.test(extType)) {
             extType = 'images';
           } else if (/woff2?|eot|ttf|otf/i.test(extType)) {
@@ -35,6 +36,12 @@ export default defineConfig(() => ({
           } else if (/css/i.test(extType)) {
             extType = 'css';
           }
+
+          // Preserve deterministic name for main stylesheet
+          if (extType === 'css' && assetInfo.name === 'index.css') {
+            return 'assets/css/index.css';
+          }
+
           return `assets/${extType}/[name]-[hash][extname]`;
         },
         chunkFileNames: 'assets/js/[name]-[hash].js',


### PR DESCRIPTION
## Summary
- preload main stylesheet via `<link>` tag
- output CSS as `assets/css/index.css`
- update service worker precache
- remove direct import of `index.css`

## Testing
- `npm run build:critical`
- `npm run lint` *(fails: 72 errors, 241 warnings)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6887980a53848320a78d1c9368a6d0a8