### PR TITLE
Fix stylesheet preload

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,11 +10,9 @@
     <link rel="preload" href="/fonts/Montserrat-Regular.ttf" as="font" type="font/ttf" crossorigin>
     <link rel="preload" href="/fonts/Montserrat-Bold.ttf" as="font" type="font/ttf" crossorigin>
     <link rel="preload" href="/fonts/Montserrat-Thin.ttf" as="font" type="font/ttf" crossorigin>
-    <link rel="stylesheet" href="/fonts/fonts.css">
 
-    <!-- Preload main stylesheet -->
-    <link rel="preload" href="/assets/css/index.css" as="style" onload="this.rel='stylesheet'">
-    <noscript><link rel="stylesheet" href="/assets/css/index.css"></noscript>
+    <!-- Main stylesheet -->
+    <link rel="stylesheet" href="/assets/css/index.css">
 
     <!-- Early hints for critical resources -->
     <link rel="dns-prefetch" href="https://img.youtube.com">


### PR DESCRIPTION
## Summary
- remove unused fonts.css link
- link stylesheet normally for immediate load
- verify fonts defined in index.css

## Testing
- `npm run lint` *(fails: 71 errors)*
- `npm run typecheck`
- `npm run build`
- `npm run preview`

------
https://chatgpt.com/codex/tasks/task_e_6887a2d5a9788320af1283d0f2c6b18f