### PR TITLE
Enable gzip/brotli compression in Vite build

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,13 @@ npm run typecheck       # TypeScript check
 npm run build && npm run preview  # Teste completo
 ```
 
+### Ativar compressão
+O build de produção gera arquivos `.gz` e `.br` para JavaScript e CSS. No Vercel,
+essas versões são servidas automaticamente quando presentes. Se utilizar outro
+provedor, verifique a documentação para habilitar o uso de arquivos
+pré-comprimidos e garanta que os cabeçalhos `Content-Encoding` sejam enviados
+corretamente.
+
 ---
 
 ## 📊 URLs do Sistema

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,8 @@
         "tailwindcss": "^3.4.11",
         "typescript": "^5.6.2",
         "typescript-eslint": "^8.0.1",
-        "vite": "^4.5.3"
+        "vite": "^4.5.3",
+        "vite-plugin-compression": "^0.5.1"
       },
       "engines": {
         "node": ">=18.0.0",
@@ -4035,6 +4036,21 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4199,6 +4215,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -4507,6 +4530,19 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -6444,6 +6480,16 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -6602,6 +6648,21 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-plugin-compression": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-compression/-/vite-plugin-compression-0.5.1.tgz",
+      "integrity": "sha512-5QJKBDc+gNYVqL/skgFAP81Yuzo9R+EAf19d+EtsMF/i8kFUpNi3J/H01QD3Oo8zBQn+NzoCIFkpPLynoOzaJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "debug": "^4.3.3",
+        "fs-extra": "^10.0.0"
+      },
+      "peerDependencies": {
+        "vite": ">=2.0.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.6.2",
     "typescript-eslint": "^8.0.1",
-    "vite": "^4.5.3"
+    "vite": "^4.5.3",
+    "vite-plugin-compression": "^0.5.1"
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,17 +1,28 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
+import compression from "vite-plugin-compression";
 
 // https://vitejs.dev/config/
-export default defineConfig(() => ({
+export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
     port: 8080,
     historyApiFallback: true,
   },
   plugins: [
-    react()
-  ],
+    react(),
+    mode === 'production' && compression({
+      algorithm: 'gzip',
+      ext: '.gz',
+      filter: /\.(js|css)$/i,
+    }),
+    mode === 'production' && compression({
+      algorithm: 'brotliCompress',
+      ext: '.br',
+      filter: /\.(js|css)$/i,
+    })
+  ].filter(Boolean),
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Summary
- add `vite-plugin-compression` to dev dependencies
- generate `.gz` and `.br` assets for JS and CSS during production builds
- document how hosting handles precompressed files

## Testing
- `npm run lint` *(fails: unused vars in temp-files)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6887bd7aae1c8320bf822e19b3c132ed