### PR TITLE
Add width/height props to ImageOptimizer

### DIFF
--- a/src/components/ImageOptimizer.tsx
+++ b/src/components/ImageOptimizer.tsx
@@ -17,6 +17,8 @@
  * @param {string} [props.className] - Classes CSS opcionais
  * @param {number} [props.aspectRatio=16/9] - Proporção da imagem (width/height)
  * @param {boolean} [props.priority=false] - Se true, carrega a imagem com prioridade alta
+ * @param {number} [props.width] - Largura da imagem em pixels
+ * @param {number} [props.height] - Altura da imagem em pixels
  * 
  * @example
  * ```tsx
@@ -54,14 +56,18 @@ interface ImageOptimizerProps {
   className?: string;
   aspectRatio?: number;
   priority?: boolean;
+  width?: number;
+  height?: number;
 }
 
-const ImageOptimizer: React.FC<ImageOptimizerProps> = ({ 
-  src, 
-  alt, 
-  className = "", 
+const ImageOptimizer: React.FC<ImageOptimizerProps> = ({
+  src,
+  alt,
+  className = "",
   aspectRatio = 16/9,
-  priority = false
+  priority = false,
+  width,
+  height
 }) => {
   const imageElement = (
     <img
@@ -69,6 +75,8 @@ const ImageOptimizer: React.FC<ImageOptimizerProps> = ({
       alt={alt}
       loading={priority ? "eager" : "lazy"}
       className={`object-cover w-full h-full ${className}`}
+      width={width}
+      height={height}
       decoding="async"
     />
   );

--- a/src/components/LogoBand.tsx
+++ b/src/components/LogoBand.tsx
@@ -11,6 +11,8 @@ const LogoBand: React.FC = () => {
           className="h-24 w-auto"
           aspectRatio={1}
           priority={false}
+          width={80}
+          height={80}
         />
         <span className="ml-4 text-white text-lg font-semibold whitespace-nowrap">
           Crédito justo, equilibrado e consciente!

--- a/src/pages/QuemSomos.tsx
+++ b/src/pages/QuemSomos.tsx
@@ -84,6 +84,8 @@ const QuemSomos = () => {
                     alt="Equipe especialista Libra Crédito em home equity e garantia de imóvel"
                     className="rounded-lg shadow-xl"
                     aspectRatio={16/9}
+                    width={2048}
+                    height={1106}
                   />
               </div>
             </div>
@@ -133,6 +135,8 @@ const QuemSomos = () => {
                   alt="Libra Crédito - Quem Somos"
                   className="rounded-xl shadow-lg w-full"
                   aspectRatio={16/9}
+                  width={480}
+                  height={320}
                 />
               </div>
             </div>


### PR DESCRIPTION
## Summary
- extend `ImageOptimizer` with optional `width` and `height` props
- supply explicit dimensions to images in `LogoBand` and `QuemSomos` pages

## Testing
- `npm run lint` *(fails: 71 errors, 241 warnings)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6887bd73b11c8320875efea9f32c7c65