### PR TITLE
Align mobile padding with Android

### DIFF
--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -77,7 +77,7 @@ const BottomNavigation: React.FC = () => {
   return (
     <>
       {/* Bottom Navigation Bar */}
-      <nav className="fixed bottom-0 left-0 right-0 z-40 bg-white border-t border-gray-200 safe-bottom">
+      <nav className="fixed bottom-0 left-0 right-0 z-40 bg-white border-t border-gray-200">
         <div className="grid grid-cols-4 h-16">
           {navItems.map((item) => {
             const Icon = item.icon;
@@ -190,7 +190,7 @@ const BottomNavigation: React.FC = () => {
             </div>
 
             {/* Contact Info */}
-            <div className="absolute bottom-0 left-0 right-0 p-4 border-t bg-gray-50 safe-bottom">
+            <div className="absolute bottom-0 left-0 right-0 p-4 border-t bg-gray-50">
               <p className="text-sm text-gray-600 text-center">
                 Atendimento: Segunda a Sexta, 9h às 18h
               </p>

--- a/src/components/MobileOptimized.tsx
+++ b/src/components/MobileOptimized.tsx
@@ -6,7 +6,7 @@ interface MobileOptimizedProps {
 }
 
 export const MobileOptimized: React.FC<MobileOptimizedProps> = ({ children }) => {
-  const { isMobile, isIOS, hasNotch } = useDevice();
+  const { isMobile, isIOS } = useDevice();
 
   useEffect(() => {
     if (!isMobile) return;
@@ -23,7 +23,6 @@ export const MobileOptimized: React.FC<MobileOptimizedProps> = ({ children }) =>
     const bodyClasses = [];
     if (isMobile) bodyClasses.push('is-mobile');
     if (isIOS) bodyClasses.push('is-ios');
-    if (hasNotch) bodyClasses.push('has-notch');
     
     document.body.classList.add(...bodyClasses);
 
@@ -95,7 +94,7 @@ export const MobileOptimized: React.FC<MobileOptimizedProps> = ({ children }) =>
       }
       document.removeEventListener('touchmove', preventPullToRefresh);
     };
-  }, [isMobile, isIOS, hasNotch]);
+  }, [isMobile, isIOS]);
 
   // Adicionar meta tags para PWA
   useEffect(() => {

--- a/src/components/MobileWizard/index.tsx
+++ b/src/components/MobileWizard/index.tsx
@@ -235,7 +235,7 @@ export const MobileWizard: React.FC<MobileWizardProps> = ({
       </div>
 
       {/* Bottom Navigation */}
-      <div className="fixed bottom-0 inset-x-0 bg-white border-t border-gray-200 p-4 safe-bottom">
+      <div className="fixed bottom-0 inset-x-0 bg-white border-t border-gray-200 p-4">
         <div className="flex gap-3">
           {currentStep > 0 && (
             <button

--- a/src/components/SimpleMobileHeader.tsx
+++ b/src/components/SimpleMobileHeader.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { useDevice } from '@/hooks/useDevice';
 import { Menu, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
@@ -9,7 +8,6 @@ interface SimpleMobileHeaderProps {
 }
 
 const SimpleMobileHeader: React.FC<SimpleMobileHeaderProps> = ({ onPortalClientes }) => {
-  const { hasNotch } = useDevice();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const location = useLocation();
   const navigate = useNavigate();
@@ -29,9 +27,9 @@ const SimpleMobileHeader: React.FC<SimpleMobileHeaderProps> = ({ onPortalCliente
   };
 
   return (
-    <header 
+    <header
       data-mobile="true"
-      className={`fixed top-0 left-0 right-0 z-[9999] bg-white border-b border-gray-200 shadow-sm ${hasNotch ? 'pt-safe-top' : ''}`}
+      className="fixed top-0 left-0 right-0 z-[9999] bg-white border-b border-gray-200 shadow-sm"
     >
       <div className="h-16 px-4 flex items-center justify-between">
         {/* Logo */}

--- a/src/index.css
+++ b/src/index.css
@@ -207,22 +207,6 @@
     padding-top: var(--header-offset-mobile);
   }
   
-  /* Safe Area Classes */
-  .pt-safe-top {
-    padding-top: var(--safe-area-top);
-  }
-  
-  .pb-safe-bottom {
-    padding-bottom: var(--safe-area-bottom);
-  }
-  
-  .pl-safe-left {
-    padding-left: var(--safe-area-left);
-  }
-  
-  .pr-safe-right {
-    padding-right: var(--safe-area-right);
-  }
   
   @media (min-width: 768px) {
     .pt-header {
@@ -494,22 +478,11 @@
   height: 100dvh;
 }
 
-/* Bottom Navigation Safe Area */
-.bottom-nav-padding {
-  padding-bottom: calc(var(--touch-target-comfortable, 56px) + var(--safe-area-bottom, 0px));
-}
-
 /* Bottom Navigation Styles */
 @layer components {
-  /* Safe padding for bottom navigation */
-  .pb-safe-nav {
-    padding-bottom: calc(80px + env(safe-area-inset-bottom));
-  }
-  
   /* Bottom Navigation Bar */
   .bottom-nav {
     @apply fixed bottom-0 left-0 right-0 z-40 bg-white border-t border-gray-200;
-    padding-bottom: env(safe-area-inset-bottom);
   }
   
   /* Special center button */


### PR DESCRIPTION
## Summary
- remove iOS safe-area padding from the simple header
- clean up bottom nav safe-area usage
- drop notch-related body class logic
- update mobile wizard bottom spacing
- delete unused safe-area CSS helpers

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6887dbec21e483209807214a189240e4