### PR TITLE
docs: add developer guide and lint ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Landing page moderna para **Libra Crédito** com sistema completo de:
 - ✅ **Integração Supabase + Blog**
 - ✅ **Formulário de parceiros**
 
+### 🧑‍💻 Documentação para Desenvolvedores
+- Consulte o [Guia de Desenvolvimento](docs/DEVELOPER_GUIDE.md) para detalhes de arquitetura, convenções e fluxo de contribuição.
+
 ---
 
 ## 🚀 Setup Rápido (5 minutos)

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -1,0 +1,78 @@
+# 🔧 GUIA DE DESENVOLVIMENTO - Libra Crédito
+
+Este documento apresenta as informações necessárias para que novos desenvolvedores possam contribuir com o projeto **Libra Crédito - Landing Page**.
+
+## 📁 Estrutura de Pastas
+
+```
+root
+├── public/                # Assets estáticos
+├── src/
+│   ├── components/        # Componentes reutilizáveis (UI)
+│   ├── pages/             # Páginas da aplicação e rotas
+│   ├── services/          # Integrações com APIs externas e Supabase
+│   ├── hooks/             # Hooks customizados (ex.: tracking)
+│   ├── utils/             # Funções utilitárias e validações
+│   └── lib/               # Configurações (Supabase, helpers)
+├── database/              # Scripts SQL e migrações
+├── scripts/               # Scripts auxiliares de build/optimizações
+└── docs/                  # Documentação adicional
+```
+
+## 🚀 Setup de Ambiente
+
+1. **Instalar dependências**
+   ```bash
+   npm install
+   ```
+2. **Configurar `.env`**
+   - Copiar `.env.example` → `.env`
+   - Definir `VITE_SUPABASE_URL` e `VITE_SUPABASE_ANON_KEY`
+   - Variáveis adicionais: `VITE_WEBHOOK_URL`, chaves de email (opcional)
+3. **Configurar Supabase**
+   - Executar `supabase-setup-complete.sql` no SQL Editor
+   - Criar bucket público `blog-images` no Storage
+
+## 🧪 Comandos de Desenvolvimento
+
+```bash
+npm run dev        # Servidor de desenvolvimento
+npm run lint       # Verificação ESLint
+npm run typecheck  # Verificação TypeScript
+npm run build      # Build de produção
+npm test           # Testes (placeholder)
+```
+
+## 🧱 Convenções de Código
+
+- **TypeScript** para todo o código fonte
+- **ESLint + TypeScript-ESLint** configurados; corrigir avisos antes de commit
+- **Tailwind CSS** para estilização
+- Componentes `shadcn/ui` seguem padrão de composição via `className`
+- Preferir hooks para lógica de negócio compartilhada
+
+## 🔗 Integrações Principais
+
+- **Supabase**: base de dados (`simulacoes`, `user_journey`, `parceiros`, `blog_posts`), autenticação e storage
+- **Serviço de Simulação**: integra API externa com fallback local
+- **Formulário de Parceiros**: envia dados ao Supabase e dispara e-mails automáticos
+
+## 📦 Deploy
+
+- Deploy padrão via **Vercel**
+- Variáveis de ambiente devem estar configuradas no painel da Vercel
+- Checar arquivo `vercel.json` para headers de segurança e rotas
+
+## 📝 Fluxo de Contribuição
+
+1. Criar branch a partir de `main`
+2. Implementar alterações seguindo convenções acima
+3. Executar `npm run lint` e `npm run typecheck`
+4. Abrir Pull Request descrevendo mudanças
+
+## 📚 Referências Úteis
+
+- [README principal](../README.md)
+- [Guia de Setup Rápido](./QUICK_START.md)
+- [Configuração de Storage](./STORAGE_SETUP_GUIDE.md)
+

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from "eslint-plugin-react-refresh";
 import tseslint from "typescript-eslint";
 
 export default tseslint.config(
-  { ignores: ["dist"] },
+  { ignores: ["dist", "temp-files/**"] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ["**/*.{ts,tsx}"],


### PR DESCRIPTION
## Summary
- add developer guide covering structure, setup, commands and conventions
- link developer guide from README
- ignore temp-files in ESLint configuration

## Testing
- `npm test`
- `npm run lint` (fails: 67 errors, 238 warnings)
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b87888983083208d5e6abf41987c54